### PR TITLE
Refactor font atlas usage

### DIFF
--- a/engine/engine/common/status.h
+++ b/engine/engine/common/status.h
@@ -19,7 +19,7 @@ typedef enum
 
 } Status;
 
-inline const char* status_to_str(Status status)
+inline const char* Status_to_str(Status status)
 {
     switch (status) 
     {

--- a/engine/engine/common/status.h
+++ b/engine/engine/common/status.h
@@ -33,13 +33,15 @@ inline const char* Status_to_str(Status status)
     }
 }
 
+// TODO: Rename?
+/*
 #ifndef NDEBUG
 #include <assert.h>
-inline void Assert(Status status) { assert(status == STATUS_OK); };
+#DEFINE Assert(Status status) { assert(status == STATUS_OK); };
 #else
 inline void Assert(Status status) {};
 #endif
-
+*/
 
 
 #endif

--- a/engine/engine/core/canvas.c
+++ b/engine/engine/core/canvas.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-Status canvas_init(Canvas* canvas, int width, int height)
+Status Canvas_init(Canvas* canvas, int width, int height)
 {
 	memset(canvas, 0, sizeof(Canvas));
 
@@ -31,7 +31,7 @@ Status canvas_init(Canvas* canvas, int width, int height)
 	return STATUS_OK;
 }
 
-Status canvas_init_from_bitmap(Canvas* canvas, const char* file)
+Status Canvas_init_from_bitmap(Canvas* canvas, const char* file)
 {
     // TODO: Do we need to use Windows.h here? If we're only loading
     //       bitmaps, the image loading code should be quite simple.

--- a/engine/engine/core/canvas.c
+++ b/engine/engine/core/canvas.c
@@ -107,7 +107,7 @@ Status Canvas_init_from_bitmap(Canvas* canvas, const char* file)
     return STATUS_OK;
 }
 
-Status canvas_write_to_bitmap(const Canvas* canvas, const char* file)
+Status Canvas_write_to_bmp(const Canvas* canvas, const char* file)
 {
     // TODO: TEMP: Copied from: https://stackoverflow.com/a/55504419
 
@@ -183,6 +183,8 @@ Status canvas_write_to_bitmap(const Canvas* canvas, const char* file)
     }
 
     fclose(imageFile);
+
+    return STATUS_OK;
 }
 
 Status canvas_resize(Canvas* canvas, int width, int height)

--- a/engine/engine/core/canvas.h
+++ b/engine/engine/core/canvas.h
@@ -14,7 +14,7 @@ typedef struct
 
 } Canvas;
 
-Status canvas_init(Canvas* canvas, int width, int height);
+Status Canvas_init(Canvas* canvas, int width, int height);
 
 Status canvas_resize(Canvas* canvas, int width, int height);
 
@@ -24,7 +24,7 @@ void canvas_draw(const Canvas* source, Canvas* target, int x_offset, int y_offse
 
 void canvas_destroy(Canvas* canvas);
 
-Status canvas_init_from_bitmap(Canvas* canvas, const char* file);
+Status Canvas_init_from_bitmap(Canvas* canvas, const char* file);
 
 Status canvas_write_to_bitmap(const Canvas* canvas, const char* file);
 

--- a/engine/engine/core/canvas.h
+++ b/engine/engine/core/canvas.h
@@ -26,6 +26,6 @@ void canvas_destroy(Canvas* canvas);
 
 Status Canvas_init_from_bitmap(Canvas* canvas, const char* file);
 
-Status canvas_write_to_bitmap(const Canvas* canvas, const char* file);
+Status Canvas_write_to_bmp(const Canvas* canvas, const char* file);
 
 #endif

--- a/engine/engine/core/engine.c
+++ b/engine/engine/core/engine.c
@@ -63,7 +63,7 @@ Status engine_init(Engine* engine, int window_width, int window_height)
     Status status = renderer_init(&engine->renderer, (int)(window_width / engine->upscaling_factor), (int)(window_height / engine->upscaling_factor));
     if (STATUS_OK != status)
     {
-        log_error("Failed to renderer_init because of %s", status_to_str(status));
+        log_error("Failed to renderer_init because of %s", Status_to_str(status));
         return status;
     }
 
@@ -71,7 +71,7 @@ Status engine_init(Engine* engine, int window_width, int window_height)
     status = window_init(&engine->window, &engine->renderer.target.canvas, (void*)engine, window_width, window_height);
     if (STATUS_OK != status)
     {
-        log_error("Failed to window_init because of %s", status_to_str(status));
+        log_error("Failed to window_init because of %s", Status_to_str(status));
         return status;
     }
 
@@ -84,7 +84,7 @@ Status engine_init(Engine* engine, int window_width, int window_height)
     status = ui_init(&engine->ui, &engine->renderer.target.canvas);
     if (STATUS_OK != status)
     {
-        log_error("Failed to ui_init because of %s", status_to_str(status));
+        log_error("Failed to ui_init because of %s", Status_to_str(status));
         return status;
     }
 

--- a/engine/engine/core/resources.h
+++ b/engine/engine/core/resources.h
@@ -34,7 +34,7 @@ inline Status resources_load_texture(Resources* resources, const char* file)
 	Texture* textures_temp = realloc(resources->textures, (size_t)(resources->textures_count + 1) * sizeof(Texture));
 	if (!textures_temp)
 	{
-		log_error("Failed to grow textures array in resources_load_texture because of %s.\n", status_to_str(STATUS_ALLOC_FAILURE));
+		log_error("Failed to grow textures array in resources_load_texture because of %s.\n", Status_to_str(STATUS_ALLOC_FAILURE));
 		return STATUS_ALLOC_FAILURE;
 	}
 	resources->textures = textures_temp;
@@ -43,7 +43,7 @@ inline Status resources_load_texture(Resources* resources, const char* file)
 	Status status = texture_load_from_bmp(&textures_temp[i], file);
 	if (STATUS_OK != status)
 	{
-		log_error("Failed to texture_load_from_bmp in resources_load_texture because of %s.\n", status_to_str(status));
+		log_error("Failed to texture_load_from_bmp in resources_load_texture because of %s.\n", Status_to_str(status));
 		return status;
 	}
 
@@ -75,16 +75,16 @@ inline Status resources_load_texture(Resources* resources, const char* file)
 	Canvas* textures_temp = realloc(resources->textures, (size_t)(resources->textures_count + 1) * sizeof(Canvas));
 	if (!textures_temp)
 	{
-		log_error("Failed to grow textures array in resources_load_texture because of %s.\n", status_to_str(STATUS_ALLOC_FAILURE));
+		log_error("Failed to grow textures array in resources_load_texture because of %s.\n", Status_to_str(STATUS_ALLOC_FAILURE));
 		return STATUS_ALLOC_FAILURE;
 	}
 	resources->textures = textures_temp;
 
 	// Try load the texture.
-	Status status = canvas_init_from_bitmap(&textures_temp[i], file);
+	Status status = Canvas_init_from_bitmap(&textures_temp[i], file);
 	if (STATUS_OK != status)
 	{
-		log_error("Failed to canvas_init_from_bitmap in resources_load_texture because of %s.\n", status_to_str(status));
+		log_error("Failed to Canvas_init_from_bitmap in resources_load_texture because of %s.\n", Status_to_str(status));
 		return status;
 	}
 

--- a/engine/engine/renderer/render_target.h
+++ b/engine/engine/renderer/render_target.h
@@ -23,7 +23,7 @@ inline Status render_target_init(RenderTarget* rt, const int width, const int he
 {
     memset(rt, 0, sizeof(RenderTarget));
 
-    Status status = canvas_init(&rt->canvas, width, height);
+    Status status = Canvas_init(&rt->canvas, width, height);
     if (STATUS_OK != status)
     {
         return status;

--- a/engine/engine/renderer/texture.h
+++ b/engine/engine/renderer/texture.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+// TODO: Refactor to simply be a canvas?? (e.g. remove texture?)
 typedef struct {
 	//float* data; // TODO: Should texture be uint32_t like Canvas again? And we can still access each component?
     Vector(float) pixels;

--- a/engine/engine/ui/font.c
+++ b/engine/engine/ui/font.c
@@ -4,58 +4,119 @@
 
 #include <Windows.h>
 
-Status font_init(Font* font)
+static int get_char_index(const Font* font, char c)
 {
-	// Initialise the font struct.
+    // TODO: Switch to a map of precalculated offsets possibly?
+    int defined = 0;
+    int char_index;
+
+    for (char_index = 0; char_index < strlen(font->defined_chars); ++char_index)
+    {
+        if (font->defined_chars[char_index] == c)
+        {
+            defined = 1;
+            break;
+        }
+    }
+
+    if (!defined)
+    {
+        log_error("Char not defined: %c", c);
+        return -1;
+    }
+
+    return char_index;
+}
+
+static int get_initial_atlas_char_offset(const Font* font, 
+    const int initial_atlas_width, char c)
+{
+    // Returns the offset to the char in the given font atlas, therefore,
+    // requires the initial atlas width.
+
+    int char_index = get_char_index(font, c);
+    if (-1 == char_index) return -1;
+
+    // Calculate the position of the char on the bitmap.
+    int cy = (char_index / font->chars_per_row);
+    int cx = char_index - font->chars_per_row * cy;
+
+    // Add one to the charHeight as there is 1 pixel between rows.
+    int rowOffset = cy * (font->char_height + 1) * initial_atlas_width;
+
+    // Add one to the charWidth as there is 1 pixel between characters.
+    int colOffset = cx * (font->char_width + 1);
+
+    return rowOffset + colOffset;
+}
+
+Status Font_init(Font* font)
+{
+    // TODO: There are strict rules about the input axis, should write these
+    //       out properly!!! pixel gap between rows/cols etc
+    
+    // Initialise the font struct.
 	memset(font, 0, sizeof(Font));
 
 	// Initialise the character data.
+    // TODO: Allow this to be set?
 	font->defined_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-=()[]{}<>/*:#%!?.,'\"@&$";
 	font->chars_per_row = 13;
 	font->char_width = 5;
 	font->char_height = 9;
 
-    // TODO: Stop hardcoding this.
-    Status status = Canvas_init_from_bitmap(&font->atlas, "C:/Users/olive/source/repos/range/res/fonts/minogram_6x10_font.bmp");
+    // Read the given font atlas.
+    Canvas src;
+    // TODO: Stop hardcoding this path.
+    Status status = Canvas_init_from_bitmap(&src, "C:/Users/olive/source/repos/range/res/fonts/minogram_6x10_font.bmp");
     if (STATUS_OK != status)
     {
-        log_error("Failed to load font bitmap, status: %s", Status_to_str(status));
+        log_error("Failed to load font atlas bitmap, status: %s", Status_to_str(status));
         return status;
+    }
+
+    // The atlas will be transformed to a flat array with no padding.
+    status = Canvas_init(&font->atlas, 
+        (size_t)(font->char_width * font->char_height) * strlen(font->defined_chars),
+        1);
+
+    // TODO: Should this sort of boilerplate error handling code simply be assertions?
+    //       Or potentially some define like RETURN_IF_FAILED(msg, status, ...)?
+    if (STATUS_OK != status)
+    {
+        log_error("Failed to init font atlas canvas, status: %s", Status_to_str(status));
+        return status;
+    }
+
+    // Rotate the atlas so that a whole char is continuous in memory, also
+    // removes any unnecessary rows/cols between src atlas chars.
+    int out = 0;
+    for (int i = 0; i < strlen(font->defined_chars); ++i)
+    {
+        int src_row = get_initial_atlas_char_offset(font, src.width,
+            font->defined_chars[i]);
+
+        for (int j = 0; j < font->char_height; ++j)
+        {
+            for (int k = 0; k < font->char_width; ++k)
+            {
+                font->atlas.pixels.data[out++] = src.pixels.data[src_row + k];
+            }
+
+            // Increment row
+            src_row += src.width;
+        }
     }
 
 	return STATUS_OK;
 }
 
-int font_get_char_index(Font* font, char c)
+int Font_get_char_offset(Font* font, char c)
 {
-	// TODO: Switch to a map of precalculated offsets possibly?
-	int defined = 0;
-	int charIndex;
-
-	for (charIndex = 0; charIndex < strlen(font->defined_chars); ++charIndex)
-	{
-		if (font->defined_chars[charIndex] == c)
-		{
-			defined = 1;
-			break;
-		}
-	}
-
-	if (!defined)
-	{
-		log_error("Char not defined: %c", c);
-		return -1;
-	}
-
-	// Calculate the position of the char on the bitmap.
-	int cy = (charIndex / font->chars_per_row);
-	int cx = charIndex - font->chars_per_row * cy;
-
-	// Add one to the charHeight as there is 1 pixel between rows.
-	int rowOffset = cy * (font->char_height + 1) * font->atlas.width;
-
-	// Add one to the charWidth as there is 1 pixel between characters.
-	int colOffset = cx * (font->char_width + 1);
-
-	return rowOffset + colOffset;
+    // TODO: Switch to a map of precalculated offsets possibly?
+    int char_index = get_char_index(font, c);
+    if (-1 == char_index) return -1;
+    
+    // Chars are stored simply in a flat array.
+    return font->char_width * font->char_height * char_index;
 }

--- a/engine/engine/ui/font.c
+++ b/engine/engine/ui/font.c
@@ -15,54 +15,13 @@ Status font_init(Font* font)
 	font->char_width = 5;
 	font->char_height = 9;
 
-	// TODO: Make this some sort of load_bitmap function.
-	// Load the bitmap containing the defined characters.
-	HBITMAP h_bitmap = LoadImageA(NULL, 
-		"C:/Users/olive/source/repos/range/res/fonts/minogram_6x10_font.bmp",
-		IMAGE_BITMAP,
-		0, 0,
-		LR_LOADFROMFILE
-	);
-
-	if (!h_bitmap)
-	{
-		log_error("Failed to load font bitmap.");
-		return STATUS_WIN32_FAILURE;
-	}
-
-	// Get bitmap properties.
-	BITMAP bitmap = { 0 };
-	GetObject(h_bitmap, sizeof(BITMAP), &bitmap);
-
-	// Create a compatible device context.
-	HDC hdc = GetDC(NULL);
-	HDC hdc_mem = CreateCompatibleDC(hdc);
-	SelectObject(hdc_mem, h_bitmap);
-
-	// Prepare bitmap info.
-	BITMAPINFO bmi;
-	ZeroMemory(&bmi, sizeof(BITMAPINFO));
-	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-	bmi.bmiHeader.biWidth = bitmap.bmWidth;
-	bmi.bmiHeader.biHeight = -bitmap.bmHeight;
-	bmi.bmiHeader.biPlanes = 1;
-	bmi.bmiHeader.biBitCount = bitmap.bmBitsPixel;
-	bmi.bmiHeader.biCompression = BI_RGB;
-
-	// Store the bitmap info.
-	font->bitmap_width = bitmap.bmWidth;
-
-	// Allocate memory for pixels.
-	font->pixels = malloc((size_t)bitmap.bmWidthBytes * bitmap.bmHeight);
-
-	// Get the pixels.
-	GetDIBits(hdc_mem, h_bitmap, 0, bitmap.bmHeight, font->pixels, &bmi, DIB_RGB_COLORS);
-
-	// Clear the bitmap.
-	if (!DeleteObject(h_bitmap))
-	{
-		log_error("Failed to release font bitmap.");
-	}
+    // TODO: Stop hardcoding this.
+    Status status = Canvas_init_from_bitmap(&font->atlas, "C:/Users/olive/source/repos/range/res/fonts/minogram_6x10_font.bmp");
+    if (STATUS_OK != status)
+    {
+        log_error("Failed to load font bitmap, status: %s", Status_to_str(status));
+        return status;
+    }
 
 	return STATUS_OK;
 }
@@ -93,7 +52,7 @@ int font_get_char_index(Font* font, char c)
 	int cx = charIndex - font->chars_per_row * cy;
 
 	// Add one to the charHeight as there is 1 pixel between rows.
-	int rowOffset = cy * (font->char_height + 1) * font->bitmap_width;
+	int rowOffset = cy * (font->char_height + 1) * font->atlas.width;
 
 	// Add one to the charWidth as there is 1 pixel between characters.
 	int colOffset = cx * (font->char_width + 1);

--- a/engine/engine/ui/font.h
+++ b/engine/engine/ui/font.h
@@ -16,8 +16,8 @@ typedef struct
 
 } Font;
 
-Status font_init(Font* font);
+Status Font_init(Font* font);
 
-int font_get_char_index(Font* font, char c);
+int Font_get_char_offset(Font* font, char c);
 
 #endif

--- a/engine/engine/ui/font.h
+++ b/engine/engine/ui/font.h
@@ -1,6 +1,7 @@
 #ifndef FONT_H
 #define FONT_H
 
+#include "core/canvas.h"
 #include "common/status.h"
 
 typedef struct
@@ -9,10 +10,9 @@ typedef struct
 	int char_height;
 	int chars_per_row;
 
-	int bitmap_width;
-
 	const char* defined_chars;
-	unsigned int* pixels;
+
+    Canvas atlas;
 
 } Font;
 

--- a/engine/engine/ui/text.c
+++ b/engine/engine/ui/text.c
@@ -62,7 +62,7 @@ void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 		int rowOffset = (row * (font->char_height + 1) * scale) * canvas->width;
 		int targetRow = startPixel + (font->char_width + 1) * scale * count + rowOffset;
 
-		int sourceRow = font_get_char_index(font, c);
+		int sourceRow = Font_get_char_offset(font, c);
 
 		if (sourceRow == -1)
 		{
@@ -81,7 +81,7 @@ void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 				int i = targetPixel;
 
 				// Only draw the filled in pixels from the source.
-				if (font->atlas.pixels.data[sourceRow + x])
+				if (font->atlas.pixels.data[sourceRow++])
 				{
 					for (int y2 = 0; y2 < scale; ++y2)
 					{
@@ -97,9 +97,6 @@ void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 				// Move the target pixel along by the pixel width.
 				targetPixel += scale;
 			}
-
-			// Increment the source row.
-			sourceRow += font->atlas.width;
 
 			// Increment the target row.
 			targetRow += canvas->width * scale;

--- a/engine/engine/ui/text.c
+++ b/engine/engine/ui/text.c
@@ -66,7 +66,7 @@ void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 
 		if (sourceRow == -1)
 		{
-			count++;
+			++count;
 			continue;
 		}
 			
@@ -81,7 +81,7 @@ void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 				int i = targetPixel;
 
 				// Only draw the filled in pixels from the source.
-				if (font->pixels[sourceRow + x])
+				if (font->atlas.pixels.data[sourceRow + x])
 				{
 					for (int y2 = 0; y2 < scale; ++y2)
 					{
@@ -99,7 +99,7 @@ void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 			}
 
 			// Increment the source row.
-			sourceRow += font->bitmap_width;
+			sourceRow += font->atlas.width;
 
 			// Increment the target row.
 			targetRow += canvas->width * scale;

--- a/engine/engine/ui/ui.c
+++ b/engine/engine/ui/ui.c
@@ -2,7 +2,7 @@
 
 Status ui_init(UI* ui, Canvas* canvas)
 {
-	Status status = font_init(&ui->font);
+	Status status = Font_init(&ui->font);
 	if (STATUS_OK != status)
 	{
 		return status;

--- a/range/main.c
+++ b/range/main.c
@@ -46,11 +46,7 @@ void create_map(Engine* engine)
     Transform* transform = ECS_get_component(&engine->ecs, cube_entity, COMPONENT_Transform);
     Transform_init(transform);
 
-
-    Assert(resources_load_texture(&engine->resources, "C:/Users/olive/source/repos/range/res/textures/rickreal.bmp"));
-
-
-    
+    resources_load_texture(&engine->resources, "C:/Users/olive/source/repos/range/res/textures/rickreal.bmp");
 
     /*
     mb_from_obj(&scene->models, &engine->renderer.buffers, "C:/Users/olive/source/repos/range/res/models/cube.obj");


### PR DESCRIPTION
Currently, when rendering a character from the font atlas, we read it row by row, this means that for each row, we may be reading the adjacent chars data into the cache. To avoid this, write out each char from the font axis in a flat array. This simplifies reading the data as well as removes any unnecessary padding between characters.