### PR TITLE
fix collision response

### DIFF
--- a/engine/engine/physics/physics.c
+++ b/engine/engine/physics/physics.c
@@ -106,12 +106,6 @@ static void apply_forces(physics_t* physics, float dt)
             // TODO: Apply friction
             // TODO: Cache .
             float speed = v3_size(physics_data->velocity);
-            if (speed > 0.f)
-            {
-                // TODO: Get some data from surfaces colliding with?
-                // TODO: Because i dont have friction, objects slide more when laggy,
-                //       friction should fix this.
-            }
 
             // TODO: essentially i need to figure out what will work best for them game. maybe just remove this for now
             //       honestly. i don't know whether we should use a physically force based drag formula that will take in mass,
@@ -152,12 +146,6 @@ static void apply_forces(physics_t* physics, float dt)
             v3_add_eq_v3(&physics_data->velocity, v3_mul_f(physics_data->impulses, 1.f / physics_data->mass));
 
             elapsed += dt;
-
-
-
-            
-            
-
 
             // Clear impulses/instantaneous forces.
             physics_data->impulses = (v3_t){ 0.f, 0.f, 0.f };

--- a/engine/engine/physics/physics_frame.h
+++ b/engine/engine/physics/physics_frame.h
@@ -53,7 +53,6 @@ typedef struct
 
 typedef struct
 {
-    v3_t rel_vel;
     v3_t collision_normal;
 
     uint8_t hit;

--- a/range/main.c
+++ b/range/main.c
@@ -19,10 +19,12 @@ mesh_base_id_t bowl_base;
 
 cecs_entity_id_t map_entity;
 cecs_entity_id_t monkey_entity;
+cecs_entity_id_t player_entity;
 
 void create_map(engine_t* engine)
 {
     resources_load_texture(&engine->resources, "C:/Users/olive/source/repos/range/res/textures/landscape.bmp");
+    resources_load_texture(&engine->resources, "C:/Users/olive/source/repos/range/res/textures/fortnite_peter.bmp");
     
     // TODO: Map like a csgo 1v1 map, just a floor and scoreboard and maybe some obstacles.
     
@@ -78,6 +80,32 @@ void create_map(engine_t* engine)
         //physics_data_init(pd);
         //pd->mass = 0.f; // TODO: TEMP: Isn't moved by other things?
         //pd->floating = 1;
+    }
+
+    // Create player
+    if(0){
+        player_entity = cecs_create_entity(engine->ecs);
+
+        // Add a mesh_instance_t component.
+        mesh_instance_t* mi = cecs_add_component(engine->ecs, player_entity, COMPONENT_MESH_INSTANCE);
+        mesh_instance_init(mi, &scene->mesh_bases.bases[cube_base]);
+
+        mi->texture_id = 1;
+
+        transform_t* transform = cecs_add_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
+        transform_init(transform);
+        transform->scale = (v3_t){ 1,2,1 };
+        transform->position = (v3_t){ 0,3,0 };
+
+        collider_t* collider = cecs_add_component(engine->ecs, player_entity, COMPONENT_COLLIDER);
+        collider_init(collider);
+
+        collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
+        collider->shape.ellipsoid = (v3_t){ 1,2,1 };
+
+        physics_data_t* pd = cecs_add_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
+        physics_data_init(pd);
+        pd->mass = 10.f;
     }
     
     // MONKEY


### PR DESCRIPTION
Fix using old relative velocity when resolving collisions, this means if something collided with two faces, it would gain twice the velocity. Instead, recalc rel_vel when resolving collisions.