### PR TITLE
Fix smooth interpolation between physics frames.

### DIFF
--- a/engine/engine/core/engine.c
+++ b/engine/engine/core/engine.c
@@ -173,37 +173,62 @@ void engine_run(engine_t* engine)
 
         snprintf(process_messages_str, sizeof(process_messages_str), "ProcMsgs: %d", timer_get_elapsed(&t));
 
+        // Calculate performance.
+        QueryPerformanceCounter(&endTime);
+        dt = (float)(endTime.QuadPart - startTime.QuadPart) / frequency.QuadPart;
+
+        dt_counter += dt;
+        physics_dt_counter += dt * g_physics_time_scale;
+
+        startTime = endTime;
+
+        fps = (int)(1.0f / dt);
+
+        if (dt_counter > 2)
+        {
+            snprintf(fps_str, sizeof(fps_str), "FPS: %d", fps);
+            dt_counter = 0;
+        }
+
+        // TODO: TEMP?
+        g_elapsed += dt;
+
         // Handle any keyboard/mouse input.
         timer_restart(&t);
         engine_handle_input(engine, dt);
         snprintf(handle_input_str, sizeof(handle_input_str), "HandleInput: %d", timer_get_elapsed(&t));
 
-        // Fire the engine update event.
+        // Fire the pre-physics event, e.g. update entity physics data, so the changes are processed
+        // this frame.
         timer_restart(&t);
-        engine_on_update(engine, dt);
-        snprintf(update_str, sizeof(update_str), "UpdateEvent: %d", timer_get_elapsed(&t));
+        engine_before_physics(engine, dt);
+        snprintf(update_str, sizeof(update_str), "EngineBeforePhysics: %d", timer_get_elapsed(&t));
        
-        m4_t view_matrix;
-        calculate_view_matrix(&engine->renderer.camera, view_matrix);
+        // Apply physics at a fixed rate.
+        timer_restart(&t);
 
-        // Apply physics
         while (physics_dt_counter >= physics_dt)
         {
-            timer_restart(&t);
-            physics_tick(&engine->physics, &engine->scene, physics_dt);
-            snprintf(physics_str, sizeof(physics_str), "Physics: %d", timer_get_elapsed(&t));
-            
+            // Move the physics world forward by a fixed step.
+            physics_tick(&engine->physics, &engine->scene, physics_dt);  
             physics_dt_counter -= physics_dt;
         }
 
-        // Essentially calculate how far are we through the physics frame. Allows us to
-        // smooth motion.
+        snprintf(physics_str, sizeof(physics_str), "Physics: %d", timer_get_elapsed(&t));
+
+        // Calculate how far we are through 
         engine->renderer.frame_data.physics_alpha = physics_dt_counter / physics_dt;
+
+        // Call after physics, e.g. update camera smoothly using physics alpha.
+        engine_after_physics(engine, engine->renderer.frame_data.physics_alpha);
         
         // Clear the canvas.
         timer_restart(&t);
         render_target_clear(&engine->renderer.target, engine->scene.bg_colour);
         snprintf(rt_clear_str, sizeof(rt_clear_str), "RTClear: %d", timer_get_elapsed(&t));
+
+        m4_t view_matrix;
+        calculate_view_matrix(&engine->renderer.camera, view_matrix);
 
         // Render scene.
         timer_restart(&t);
@@ -257,23 +282,6 @@ void engine_run(engine_t* engine)
         window_display(&engine->window);
         snprintf(display_str, sizeof(display_str), "Display: %d", timer_get_elapsed(&t));
 
-        // Calculate performance.
-        QueryPerformanceCounter(&endTime);
-        dt = (float)(endTime.QuadPart - startTime.QuadPart) / frequency.QuadPart;
-
-        dt_counter += dt;
-        physics_dt_counter += dt * g_physics_time_scale;
-
-        startTime = endTime;
-
-        fps = (int)(1.0f / dt);
-        
-        if (dt_counter > 2)
-        {
-            snprintf(fps_str, sizeof(fps_str), "FPS: %d", fps);
-            dt_counter = 0;
-        }
-
         snprintf(dir_str, sizeof(dir_str), "DIR: %.2f %.2f %.2f", engine->renderer.camera.direction.x, engine->renderer.camera.direction.y, engine->renderer.camera.direction.z);
         snprintf(pos_str, sizeof(pos_str), "POS: %.2f %.2f %.2f", engine->renderer.camera.position.x, engine->renderer.camera.position.y, engine->renderer.camera.position.z);
         
@@ -323,13 +331,6 @@ void engine_run(engine_t* engine)
             }
             snprintf(input_mode_str, sizeof(input_mode_str), "INPUT MODE: %s", mode);
         }
-        
-
-        
-
-
-        // TODO: TEMP?
-        g_elapsed += dt;        
     }
 }
 

--- a/engine/engine/core/engine.h
+++ b/engine/engine/core/engine.h
@@ -71,7 +71,8 @@ void engine_destroy(engine_t* engine);
 // Public engine events that the game should define.
 void engine_on_init(engine_t* engine);
 
-void engine_on_update(engine_t* engine, float dt);
+void engine_before_physics(engine_t* engine, float dt);
+void engine_after_physics(engine_t* engine, float physics_alpha);
 
 void engine_on_keyup(engine_t* engine, WPARAM wParam);
 

--- a/engine/engine/physics/physics.h
+++ b/engine/engine/physics/physics.h
@@ -50,6 +50,8 @@ typedef struct physics_data
 void physics_data_init(physics_data_t* data);
 
 status_t physics_init(physics_t* physics, cecs_t* ecs);
+
 void physics_tick(physics_t* physics, scene_t* scene, float dt);
+
 
 #endif

--- a/engine/engine/scripts/gameplay/player_controller.h
+++ b/engine/engine/scripts/gameplay/player_controller.h
@@ -8,7 +8,7 @@
 // TODO: Refactor this script to really make sense, e.g. we can pass in a camera offset.
 uint8_t third_person = 1;
 
-inline void player_controller(engine_t* engine, cecs_entity_id_t eid, float dt)
+inline void player_controller_physics(engine_t* engine, cecs_entity_id_t eid, float dt)
 {
     if (engine->input_mode != INPUT_MODE_GAME) return;
 
@@ -60,7 +60,18 @@ inline void player_controller(engine_t* engine, cecs_entity_id_t eid, float dt)
         // TODO: Only if colliding with something???
         const float jump_height = pd->mass;
         v3_add_eq_v3(&pd->impulses, v3_mul_f(up, jump_height));   
-    }
+    }    
+}
+
+inline void player_controller_camera(engine_t* engine, cecs_entity_id_t eid)
+{
+    if (engine->input_mode != INPUT_MODE_GAME) return;
+
+    transform_t* t = cecs_get_component(engine->ecs, eid, COMPONENT_TRANSFORM);
+
+    const static v3_t up = { 0, 1.f, 0 };
+    const v3_t forward = v3_normalised((v3_t) { engine->renderer.camera.direction.x, 0.f, engine->renderer.camera.direction.z });
+    const v3_t right = v3_normalised(cross(forward, up));
 
     v3_t player_pos = v3_lerp(t->previous_position, t->position, engine->renderer.frame_data.physics_alpha);
     if (third_person)
@@ -78,7 +89,8 @@ inline void player_controller(engine_t* engine, cecs_entity_id_t eid, float dt)
     {
         engine->renderer.camera.position = player_pos;
     }
-    
 }
+
+
 
 #endif

--- a/game/main.c
+++ b/game/main.c
@@ -212,7 +212,7 @@ void engine_on_init(engine_t* engine)
     create_map(engine);
 }
 
-void engine_on_update(engine_t* engine, float dt)
+void engine_before_physics(engine_t* engine, float dt)
 {
     {
         physics_data_t* pd = cecs_get_component(engine->ecs, map_entity, COMPONENT_PHYSICS_DATA);
@@ -229,8 +229,13 @@ void engine_on_update(engine_t* engine, float dt)
 
     }
 
-    player_controller(engine, player_entity, dt);
+    player_controller_physics(engine, player_entity, dt);
     update_billboard(engine, billboard_entity, dt);
+}
+
+void engine_after_physics(engine_t* engine, float physics_alpha)
+{
+    player_controller_camera(engine, player_entity);
 }
 
 void engine_on_keyup(engine_t* engine, WPARAM wParam)


### PR DESCRIPTION
- Move dt calculation just before first usage.
- Split engine_on_update to engine_before/after_physics.
- Apply impulses (player_controller) before physics.
- Interpolate camera position after physics alpha calculated.
- Move view matrix calculation after physics updates positions.

Note, may re-add engine_on_update and may rename engine_before/after_physics to engine_on_before/after_physics.