### PR TITLE
switch to PascalCase naming for structs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ﻿# CMakeList.txt : Top-level CMake project file, do global configuration
 # and include sub-projects here.
 #
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_reqUIred (VERSION 3.8)
 
 project ("game" C)
 

--- a/engine/engine/common/status.h
+++ b/engine/engine/common/status.h
@@ -15,9 +15,9 @@ typedef enum
 	STATUS_ALLOC_FAILURE,
     STATUS_FILE_FAILURE
 
-} status_t;
+} Status;
 
-inline const char* status_to_str(status_t status)
+inline const char* status_to_str(Status status)
 {
     switch (status) 
     {
@@ -27,7 +27,7 @@ inline const char* status_to_str(status_t status)
         case STATUS_WIN32_FAILURE:      return "Win32 Failure";
         case STATUS_ALLOC_FAILURE:      return "Alloc Failure";
         case STATUS_FILE_FAILURE:       return "File Failure";
-        default:                        return "Unknown status_t";
+        default:                        return "Unknown Status";
     }
 }
 
@@ -35,9 +35,9 @@ inline const char* status_to_str(status_t status)
 /*
 #ifndef NDEBUG
 #include <assert.h>
-#DEFINE Assert(status_t status) { assert(status == STATUS_OK); };
+#DEFINE Assert(Status status) { assert(status == STATUS_OK); };
 #else
-inline void Assert(status_t status) {};
+inline void Assert(Status status) {};
 #endif
 */
 

--- a/engine/engine/core/canvas.c
+++ b/engine/engine/core/canvas.c
@@ -9,9 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-status_t canvas_init(canvas_t* canvas, int width, int height)
+Status canvas_init(Canvas* canvas, int width, int height)
 {
-	memset(canvas, 0, sizeof(canvas_t));
+	memset(canvas, 0, sizeof(Canvas));
 
 	canvas->width = width;
 	canvas->height = height;
@@ -31,13 +31,13 @@ status_t canvas_init(canvas_t* canvas, int width, int height)
 	return STATUS_OK;
 }
 
-status_t canvas_init_from_bitmap(canvas_t* canvas, const char* file)
+Status canvas_init_from_bitmap(Canvas* canvas, const char* file)
 {
     // TODO: Do we need to use Windows.h here? If we're only loading
     //       bitmaps, the image loading code should be quite simple.
 
     // Initialise the texture.
-    memset(canvas, 0, sizeof(canvas_t));
+    memset(canvas, 0, sizeof(Canvas));
         
     // Try load the bitmap.
     HBITMAP h_bitmap = (HBITMAP)LoadImageA(
@@ -107,7 +107,7 @@ status_t canvas_init_from_bitmap(canvas_t* canvas, const char* file)
     return STATUS_OK;
 }
 
-status_t canvas_write_to_bmp(const canvas_t* canvas, const char* file)
+Status canvas_write_to_bmp(const Canvas* canvas, const char* file)
 {
     // TODO: TEMP: Copied from: https://stackoverflow.com/a/55504419
 
@@ -187,7 +187,7 @@ status_t canvas_write_to_bmp(const canvas_t* canvas, const char* file)
     return STATUS_OK;
 }
 
-status_t canvas_resize(canvas_t* canvas, int width, int height)
+Status canvas_resize(Canvas* canvas, int width, int height)
 {
 	// Check the size has changed.
 	if (canvas->width == width && canvas->height == height)
@@ -214,7 +214,7 @@ status_t canvas_resize(canvas_t* canvas, int width, int height)
 	return STATUS_OK;
 }
 
-void canvas_fill(canvas_t* canvas, const unsigned int colour)
+void canvas_fill(Canvas* canvas, const unsigned int colour)
 {
 	// TODO: Look for some sort of blit or fill function 
 	const int length = canvas->width * canvas->height;	
@@ -230,7 +230,7 @@ void canvas_fill(canvas_t* canvas, const unsigned int colour)
 	}
 }
 
-void canvas_draw(const canvas_t* source, canvas_t* target, int x_offset, int y_offset)
+void canvas_draw(const Canvas* source, Canvas* target, int x_offset, int y_offset)
 {
     int* source_data = source->pixels;
     int* target_data = target->pixels;
@@ -244,7 +244,7 @@ void canvas_draw(const canvas_t* source, canvas_t* target, int x_offset, int y_o
     }
 }
 
-void canvas_destroy(canvas_t* canvas)
+void canvas_destroy(Canvas* canvas)
 {
     chds_vec_destroy(canvas->pixels);
 

--- a/engine/engine/core/canvas.h
+++ b/engine/engine/core/canvas.h
@@ -12,20 +12,20 @@ typedef struct
 	int width, height;
 	CHDS_VEC(uint32_t) pixels;
 
-} canvas_t;
+} Canvas;
 
-status_t canvas_init(canvas_t* canvas, int width, int height);
+Status canvas_init(Canvas* canvas, int width, int height);
 
-status_t canvas_resize(canvas_t* canvas, int width, int height);
+Status canvas_resize(Canvas* canvas, int width, int height);
 
-void canvas_fill(canvas_t* canvas, const unsigned int colour);
+void canvas_fill(Canvas* canvas, const unsigned int colour);
 
-void canvas_draw(const canvas_t* source, canvas_t* target, int x_offset, int y_offset);
+void canvas_draw(const Canvas* source, Canvas* target, int x_offset, int y_offset);
 
-void canvas_destroy(canvas_t* canvas);
+void canvas_destroy(Canvas* canvas);
 
-status_t canvas_init_from_bitmap(canvas_t* canvas, const char* file);
+Status canvas_init_from_bitmap(Canvas* canvas, const char* file);
 
-status_t canvas_write_to_bmp(const canvas_t* canvas, const char* file);
+Status canvas_write_to_bmp(const Canvas* canvas, const char* file);
 
 #endif

--- a/engine/engine/core/components.h
+++ b/engine/engine/core/components.h
@@ -11,11 +11,11 @@
 #include <cecs/ecs.h>
 
 #define CORE_COMPONENTS_LIST          \
-    X(MESH_INSTANCE, mesh_instance_t) \
-    X(POINT_LIGHT, point_light_t)     \
-    X(TRANSFORM, transform_t)         \
-    X(PHYSICS_DATA, physics_data_t)   \
-    X(COLLIDER, collider_t)
+    X(MESH_INSTANCE, MeshInstance) \
+    X(POINT_LIGHT, PointLight)     \
+    X(TRANSFORM, Transform)         \
+    X(PHYSICS_DATA, PhysicsData)   \
+    X(COLLIDER, Collider)
 
 #define X(name, T) cecs_component_id COMPONENT_##name;
     CORE_COMPONENTS_LIST

--- a/engine/engine/core/engine.c
+++ b/engine/engine/core/engine.c
@@ -16,12 +16,12 @@
 #include <stdlib.h>
 
 // Internal helpers.
-static void engine_setup_ecs(engine_t* engine)
+static void engine_setup_ecs(Engine* engine)
 {
     cecs* ecs = cecs_create();
     engine->ecs = ecs;
 
-    // Setup core components, mesh_instance_t etc.
+    // Setup core components, MeshInstance etc.
     core_components_init(ecs);
 
     // TODO: Systems should initialise their own views.
@@ -34,10 +34,10 @@ static void engine_setup_ecs(engine_t* engine)
     engine->lighting_view_id = cecs_view_create(ecs, CECS_COMPONENT_ID_TO_BITSET(COMPONENT_POINT_LIGHT), 0);
 }
 
-status_t engine_init(engine_t* engine, int window_width, int window_height)
+Status engine_init(Engine* engine, int window_width, int window_height)
 {
     log_info("Initialising the engine.");
-    memset(engine, 0, sizeof(engine_t));
+    memset(engine, 0, sizeof(Engine));
 
     // Set some default settings.
     engine->upscaling_factor = 1;
@@ -47,7 +47,7 @@ status_t engine_init(engine_t* engine, int window_width, int window_height)
     engine_setup_ecs(engine);
 
     // Initialise the renderer.
-    status_t status = renderer_init(&engine->renderer, (int)(window_width / engine->upscaling_factor), (int)(window_height / engine->upscaling_factor));
+    Status status = renderer_init(&engine->renderer, (int)(window_width / engine->upscaling_factor), (int)(window_height / engine->upscaling_factor));
     if (STATUS_OK != status)
     {
         log_error("Failed to renderer_init because of %s", status_to_str(status));
@@ -67,11 +67,11 @@ status_t engine_init(engine_t* engine, int window_width, int window_height)
     engine->window.on_keyup = &engine_process_keyup;
     engine->window.on_lmbdown = &engine_process_lmbdown;
 
-    // Initialise the ui_t.
-    status = ui_init(&engine->ui, &engine->renderer.target.canvas);
+    // Initialise the UI.
+    status = UI_init(&engine->UI, &engine->renderer.target.canvas);
     if (STATUS_OK != status)
     {
-        log_error("Failed to ui_init because of %s", status_to_str(status));
+        log_error("Failed to UI_init because of %s", status_to_str(status));
         return status;
     }
 
@@ -91,12 +91,12 @@ status_t engine_init(engine_t* engine, int window_width, int window_height)
     log_info("Fired engine_on_init event.");
     engine_on_init(engine);
 
-    log_info("engine_t successfully initialised.");
+    log_info("Engine successfully initialised.");
 
     return STATUS_OK;
 }
 
-void engine_run(engine_t* engine)
+void engine_run(Engine* engine)
 {
     // TODO: Outline somewhere nicer.
     const float physics_dt = 1.f / 60.f; // 60fps
@@ -115,7 +115,7 @@ void engine_run(engine_t* engine)
     // TODO: Struct of perf data?
     int fps = 0;
     float dt = 0;
-    int draw_ui_ms = 0;
+    int draw_UI_ms = 0;
 
     // Start the timers.
     QueryPerformanceCounter(&startTime);
@@ -131,7 +131,7 @@ void engine_run(engine_t* engine)
     char handle_input_str[64] = "";
     char rt_clear_str[64] = "";
     char render_str[64] = "";
-    char ui_draw_str[64] = "";
+    char UI_draw_str[64] = "";
     char display_str[64] = "";
     char update_str[64] = "";
     char vertices_str[64] = "";
@@ -139,24 +139,24 @@ void engine_run(engine_t* engine)
     char input_mode_str[64] = "";
     
 
-    // TODO: This can be a ui add text function
+    // TODO: This can be a UI add text function
     int y = 10;
     const int TEXT_SCALE = 1;
-    int h = engine->ui.font.char_height * TEXT_SCALE;
+    int h = engine->UI.font.char_height * TEXT_SCALE;
     
-    engine->ui.text[engine->ui.text_count++] = text_create(fps_str, 10, engine->ui.text_count * h + 10, COLOUR_LIME, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(dir_str, 10, engine->ui.text_count * h + 10, COLOUR_RED, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(pos_str, 10, engine->ui.text_count * h + 10, COLOUR_RED, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(process_messages_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(handle_input_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(rt_clear_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(render_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(ui_draw_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(display_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(update_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(vertices_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(physics_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
-    engine->ui.text[engine->ui.text_count++] = text_create(input_mode_str, 10, engine->ui.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(fps_str, 10, engine->UI.text_count * h + 10, COLOUR_LIME, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(dir_str, 10, engine->UI.text_count * h + 10, COLOUR_RED, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(pos_str, 10, engine->UI.text_count * h + 10, COLOUR_RED, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(process_messages_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(handle_input_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(rt_clear_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(render_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(UI_draw_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(display_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(update_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(vertices_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(physics_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
+    engine->UI.text[engine->UI.text_count++] = text_create(input_mode_str, 10, engine->UI.text_count * h + 10, COLOUR_WHITE, TEXT_SCALE);
 
     engine->running = 1;
 
@@ -164,7 +164,7 @@ void engine_run(engine_t* engine)
 
     while (engine->running)
     {
-        timer_t t = timer_start();
+        Timer t = timer_start();
 
         // Process the application window messages.
         if (!window_process_messages())
@@ -229,7 +229,7 @@ void engine_run(engine_t* engine)
         render_target_clear(&engine->renderer.target, engine->scene.bg_colour);
         snprintf(rt_clear_str, sizeof(rt_clear_str), "RTClear: %d", timer_get_elapsed(&t));
 
-        m4_t view_matrix;
+        M4 view_matrix;
         calculate_view_matrix(&engine->renderer.camera, view_matrix);
 
         // Render scene.
@@ -245,11 +245,11 @@ void engine_run(engine_t* engine)
         
         snprintf(render_str, sizeof(render_str), "Render: %d", timer_get_elapsed(&t));
          
-        // Draw ui elements.
+        // Draw UI elements.
         timer_restart(&t);
-        ui_draw(&engine->ui, engine->upscaling_factor);
-        snprintf(ui_draw_str, sizeof(render_str), "DrawUI: %d", draw_ui_ms);
-        draw_ui_ms = timer_get_elapsed(&t); // Must be done a frame late.
+        UI_draw(&engine->UI, engine->upscaling_factor);
+        snprintf(UI_draw_str, sizeof(render_str), "DrawUI: %d", draw_UI_ms);
+        draw_UI_ms = timer_get_elapsed(&t); // Must be done a frame late.
 
         // TODO: TEMP: Debugging rendering the velocities.
         if (g_debug_velocities) 
@@ -259,20 +259,20 @@ void engine_run(engine_t* engine)
 
             while (cecs_view_iter_next(&it))
             {
-                transform_t* ts = cecs_get_column(it, COMPONENT_TRANSFORM);
-                physics_data_t* pds = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
+                Transform* ts = cecs_get_column(it, COMPONENT_TRANSFORM);
+                PhysicsData* pds = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
 
                 for (uint32_t i = 0; i < it.num_entities; ++i)
                 {
-                    v3_t vel = pds[i].velocity;
+                    V3 vel = pds[i].velocity;
                     float speed = v3_size(vel);
                     if (speed == 0.f) continue;
 
-                    //v3_t dir = v3_mul_f(vel, 1.f / speed);
-                    v3_t dir = vel;
-                    v3_t start = ts[i].position;
-                    v3_t end = v3_add_v3(start, v3_mul_f(dir, 1.f));
-                    debug_draw_world_space_line(&engine->renderer.target.canvas, &engine->renderer.settings, view_matrix, start, end, (v3_t) { 1, 0,0 });
+                    //V3 dir = v3_mul_f(vel, 1.f / speed);
+                    V3 dir = vel;
+                    V3 start = ts[i].position;
+                    V3 end = v3_add_v3(start, v3_mul_f(dir, 1.f));
+                    debug_draw_world_space_line(&engine->renderer.target.canvas, &engine->renderer.settings, view_matrix, start, end, (V3) { 1, 0,0 });
 
                 }
             }
@@ -295,14 +295,14 @@ void engine_run(engine_t* engine)
             cecs_view_iter it = cecs_view_iter_create(ecs, engine->render_view_id);
             while (cecs_view_iter_next(&it))
             {
-                mesh_instance_t* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
+                MeshInstance* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
 
                 for (int i = 0; i < it.num_entities; ++i)
                 {
-                    mesh_instance_t* mi = &mis[i];
+                    MeshInstance* mi = &mis[i];
 
-                    const scene_t* scene = &engine->scene;
-                    const mesh_base_t* mb = &scene->mesh_bases.bases[mi->mb_id];
+                    const Scene* scene = &engine->scene;
+                    const MeshBase* mb = &scene->mesh_bases.bases[mi->mb_id];
                     total_faces += mb->num_faces;
                     ++mis_count;
                 }
@@ -336,14 +336,14 @@ void engine_run(engine_t* engine)
     }
 }
 
-void engine_destroy(engine_t* engine)
+void engine_destroy(Engine* engine)
 {
     // TODO: this stuff.
-    ui_destroy(&engine->ui);
+    UI_destroy(&engine->UI);
     window_destroy(&engine->window);
 }
 
-void engine_handle_input(engine_t* engine, float dt)
+void engine_handle_input(Engine* engine, float dt)
 {
     // Note the mouse state is updated elsewhere
     // Update keyboard state.
@@ -361,7 +361,7 @@ void engine_handle_input(engine_t* engine, float dt)
     }
 
     // TODO: Should pass to noclip controller function.
-    camera_t* camera = &engine->renderer.camera;
+    Camera* camera = &engine->renderer.camera;
 
     // TODO: Could move this to an input handler or something. 
     //       Not sure if necessary.
@@ -435,15 +435,15 @@ void engine_handle_input(engine_t* engine, float dt)
     }
     if (CSRGE_KEYDOWN(keys['A']))
     {
-        v3_t up = { 0, 1, 0 };
-        v3_t right = v3_normalised(cross(camera->direction, up));
+        V3 up = { 0, 1, 0 };
+        V3 right = v3_normalised(cross(camera->direction, up));
 
         v3_sub_eq_v3(&camera->position, v3_mul_f(right, meters_per_second));
     }
     if (CSRGE_KEYDOWN(keys['D']))
     {
-        v3_t up = { 0, 1, 0 };
-        v3_t right = v3_normalised(cross(camera->direction, up));
+        V3 up = { 0, 1, 0 };
+        V3 right = v3_normalised(cross(camera->direction, up));
 
         v3_add_eq_v3(&camera->position, v3_mul_f(right, meters_per_second));
     }
@@ -457,12 +457,12 @@ void engine_handle_input(engine_t* engine, float dt)
     }
 }
 
-// window_t events
+// Window events
 static void engine_on_resize(void* ctx)
 {
-    engine_t* engine = (engine_t*)ctx;
+    Engine* engine = (Engine*)ctx;
 
-    status_t status = renderer_resize(&engine->renderer, 
+    Status status = renderer_resize(&engine->renderer, 
         (int)(engine->window.width / engine->upscaling_factor), 
         (int)(engine->window.height / engine->upscaling_factor));
 
@@ -483,7 +483,7 @@ static void engine_process_keyup(void* ctx, WPARAM wParam)
 {
     // TODO: Handle failure for all these win32 calls??
 
-    engine_t* engine = (engine_t*)ctx;
+    Engine* engine = (Engine*)ctx;
 
     // Handle any engine specific keybinds, if
     // not engine specific, pass to user callback.
@@ -494,7 +494,7 @@ static void engine_process_keyup(void* ctx, WPARAM wParam)
         ++engine->input_mode;
         if (engine->input_mode == INPUT_MODE_INVALID)
         {
-            engine->input_mode = (input_mode_t)0;
+            engine->input_mode = (InputMode)0;
         }
 
         switch (engine->input_mode)
@@ -575,7 +575,7 @@ static void engine_process_keyup(void* ctx, WPARAM wParam)
 
 static void engine_process_lmbdown(void* ctx)
 {
-    engine_t* engine = (engine_t*)ctx;
+    Engine* engine = (Engine*)ctx;
 
     engine_on_lmbdown(ctx);
 }

--- a/engine/engine/core/engine.h
+++ b/engine/engine/core/engine.h
@@ -7,7 +7,7 @@
 #include "resources.h"
 #include "components.h"
 
-#include "ui/ui.h"
+#include "UI/UI.h"
 
 // TODO: These need to be refactored.
 #include "renderer/renderer.h"
@@ -23,7 +23,7 @@ typedef enum input_mode
     INPUT_MODE_NOCLIP,
     INPUT_MODE_GAME,
     INPUT_MODE_INVALID
-} input_mode_t;
+} InputMode;
 
 typedef struct
 {
@@ -37,52 +37,52 @@ typedef struct
     cecs_view_id moving_collider_view_id;
     cecs_view_id static_collider_view_id;
 
-	// engine_t components.
-	window_t window;
-	ui_t ui;
-	renderer_t renderer;
-	resources_t resources; // Works fine for now, potentially something to refactor.
-    physics_t physics;
+	// Engine components.
+	Window window;
+	UI UI;
+	Renderer renderer;
+	Resources resources; // Works fine for now, potentially something to refactor.
+    Physics physics;
 
 	// Scene data. - I don't think the engine needs to manage multiple.
     // TODO: Only manage one scene.
-	scene_t scene;
+	Scene scene;
 
     // TODO: Stuff like this is private?
 
-	// engine_t settings
+	// Engine settings
 	int running;
 
 	// TODO: Move these somewhere?
-    input_mode_t input_mode;
+    InputMode input_mode;
 	float upscaling_factor;
 
 	// TODO: Allow the user to set callbacks just like the window class.
 
-} engine_t;
+} Engine;
 
 // Main API
-status_t engine_init(engine_t* engine, int window_width, int window_height);
+Status engine_init(Engine* engine, int window_width, int window_height);
 
-void engine_run(engine_t* engine);
+void engine_run(Engine* engine);
 
-void engine_destroy(engine_t* engine);
+void engine_destroy(Engine* engine);
 
 // Public engine events that the game should define.
-void engine_on_init(engine_t* engine);
+void engine_on_init(Engine* engine);
 
-void engine_before_physics(engine_t* engine, float dt);
-void engine_after_physics(engine_t* engine, float physics_alpha);
+void engine_before_physics(Engine* engine, float dt);
+void engine_after_physics(Engine* engine, float physics_alpha);
 
-void engine_on_keyup(engine_t* engine, WPARAM wParam);
+void engine_on_keyup(Engine* engine, WPARAM wParam);
 
-void engine_on_lmbdown(engine_t* engine);
+void engine_on_lmbdown(Engine* engine);
 
 // Internal functions
 
 
 // TODO: Some sort of input handler? Fine here for now.
-void engine_handle_input(engine_t* engine, float dt);
+void engine_handle_input(Engine* engine, float dt);
 
 // Private window events.
 static void engine_on_resize(void* ctx);

--- a/engine/engine/core/globals.h
+++ b/engine/engine/core/globals.h
@@ -6,7 +6,7 @@
 // Currently this file is just for sharing values between files without changing
 // lots of stuff.
 
-// In the future, this could be for defining ui values for text etc.
+// In the future, this could be for defining UI values for text etc.
 int g_draw_normals;
 int g_debug_shadows;
 uint8_t g_debug_velocities;

--- a/engine/engine/core/lights.c
+++ b/engine/engine/core/lights.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 
 /*
-void point_light_init(point_light_t* light, v3_t position, v3_t colour, float strength)
+void point_light_init(PointLight* light, V3 position, V3 colour, float strength)
 {
 	const int new_count = point_lights->count + 1;
 
@@ -42,7 +42,7 @@ void point_light_init(point_light_t* light, v3_t position, v3_t colour, float st
 	point_lights->count = new_count;
 
 	// Create a new depth buffer for the new light.
-	depth_buffer_t* temp = realloc(point_lights->depth_maps, (size_t)point_lights->count * sizeof(depth_buffer_t));
+	DepthBuffer* temp = realloc(point_lights->depth_maps, (size_t)point_lights->count * sizeof(DepthBuffer));
 	if (!temp)
 	{
 		log_error("Failed to realloc for point_lights->depth_maps.");
@@ -60,15 +60,15 @@ void point_light_init(point_light_t* light, v3_t position, v3_t colour, float st
 */
 
 
-status_t point_light_init(point_light_t* light)
+Status point_light_init(PointLight* light)
 {
-    memset(light, 0, sizeof(point_light_t));
+    memset(light, 0, sizeof(PointLight));
     light->strength = 1.f;
 
     return STATUS_OK;
 }
 
-void PointLight_destroy(point_light_t* light)
+void PointLight_destroy(PointLight* light)
 {
 }
 

--- a/engine/engine/core/lights.h
+++ b/engine/engine/core/lights.h
@@ -19,36 +19,36 @@ a red colour.
 
 */
 
-typedef int point_light_id_t;
-typedef int shadow_casting_point_light_id_t;
+typedef int PointLightId;
+typedef int ShadowCastingPointLightId;
 
-// TODO: This having a position is a bit of an issue if we want to connect it to physics, do we want transform_t here?
+// TODO: This having a position is a bit of an issue if we want to connect it to physics, do we want Transform here?
 typedef struct
 {
-	v3_t position;
-	v3_t colour;
+	V3 position;
+	V3 colour;
 	float strength;
 
-} point_light_t;
+} PointLight;
 
 
 typedef struct
 {
-	v3_t position;
-	v3_t colour;
+	V3 position;
+	V3 colour;
 	float strength;
 
-	depth_buffer_t* depth_maps;
+	DepthBuffer* depth_maps;
 
-} shadow_casting_point_light_t;
+} ShadowCastingPointLight;
 
 
 // I think in terms of API for example, when creating shadow casting lights,
 // we just want the user to call this, and this can create the shadow map?
-//status_t point_lights_add(PointLights* point_lights, point_light_t point_light);
-//status_t point_lights_add_shadow_casting(PointLights* point_lights, shadow_casting_point_light_t point_light);
+//Status point_lights_add(PointLights* point_lights, PointLight point_light);
+//Status point_lights_add_shadow_casting(PointLights* point_lights, ShadowCastingPointLight point_light);
 
-status_t point_light_init(point_light_t* light);
+Status point_light_init(PointLight* light);
 
 
 #endif

--- a/engine/engine/core/mesh_base.c
+++ b/engine/engine/core/mesh_base.c
@@ -45,14 +45,14 @@ void parse_obj_counts(FILE* file, int* num_positions, int* num_uvs, int* num_nor
 	}
 }
 
-// mesh_base_t API
-status_t mesh_base_init(mesh_base_t* mb)
+// MeshBase API
+Status mesh_base_init(MeshBase* mb)
 {
-	memset(mb, 0, sizeof(mesh_base_t));
+	memset(mb, 0, sizeof(MeshBase));
 	return STATUS_OK;
 }
 
-status_t mesh_base_from_obj(mesh_base_t* mb, const char* filename)
+Status mesh_base_from_obj(MeshBase* mb, const char* filename)
 {
 	// TODO: Eventually could check the filetype.
 	FILE* file = fopen(filename, "r");
@@ -226,7 +226,7 @@ status_t mesh_base_from_obj(mesh_base_t* mb, const char* filename)
 	return STATUS_OK;
 }
 
-void mesh_base_destroy(mesh_base_t* mb)
+void mesh_base_destroy(MeshBase* mb)
 {
     chds_vec_destroy(mb->object_space_positions);
 	chds_vec_destroy(mb->object_space_normals);
@@ -236,18 +236,18 @@ void mesh_base_destroy(mesh_base_t* mb)
 	chds_vec_destroy(mb->uv_indices);
 }
 
-// mesh_bases_t API
-status_t mesh_bases_init(mesh_bases_t* mbs)
+// MeshBases API
+Status mesh_bases_init(MeshBases* mbs)
 {
-	memset(mbs, 0, sizeof(mesh_bases_t));
+	memset(mbs, 0, sizeof(MeshBases));
 	return STATUS_OK;
 }
 
-mesh_base_id_t mesh_bases_add(mesh_bases_t* mbs)
+MeshBaseId mesh_bases_add(MeshBases* mbs)
 {
 	// Grow the array of mesh instances.
 	const int new_count = mbs->count + 1;
-	mesh_base_t* new_bases = realloc(mbs->bases, new_count * sizeof(mesh_base_t));
+	MeshBase* new_bases = realloc(mbs->bases, new_count * sizeof(MeshBase));
 
 	if (!new_bases)
 	{
@@ -255,20 +255,20 @@ mesh_base_id_t mesh_bases_add(mesh_bases_t* mbs)
 		return STATUS_ALLOC_FAILURE;
 	}
 
-	const mesh_base_id_t mb_id = mbs->count;
+	const MeshBaseId mb_id = mbs->count;
 
 	mbs->bases = new_bases;
 	mbs->count = new_count;
 
-	// Initialise the new mesh_base_t.
-	mesh_base_t* mb = &mbs->bases[mb_id];
+	// Initialise the new MeshBase.
+	MeshBase* mb = &mbs->bases[mb_id];
 	mesh_base_init(mb);
 	mb->id = mb_id;
 
 	return mb_id;
 }
 
-void mesh_bases_destroy(mesh_bases_t* mbs)
+void mesh_bases_destroy(MeshBases* mbs)
 {
 	free(mbs->bases);
 }

--- a/engine/engine/core/mesh_base.h
+++ b/engine/engine/core/mesh_base.h
@@ -12,26 +12,26 @@
 
 /*
 
-A mesh_base_t stores the static data of a Mesh. 
+A MeshBase stores the static data of a Mesh. 
 Currently, it essentially is a struct for a parsed .obj file.
 
-A mesh_instance_t will store the ID of a mesh_base_t and read any static data from
+A MeshInstance will store the ID of a MeshBase and read any static data from
 there, therefore, if the base's data was edited, all instances would also be
 updated.
 
-It doesn't make sense to iterate over each mesh_base_t, therefore, there is no
+It doesn't make sense to iterate over each MeshBase, therefore, there is no
 need for use of DOD.
 
-It also doesn't really make sense to remove a mesh_base_t, so the mesh_base_id_t will
+It also doesn't really make sense to remove a MeshBase, so the MeshBaseId will
 always remain valid as an index without extra indirection logic.
 
 */
 
-typedef int mesh_base_id_t;
+typedef int MeshBaseId;
 
 typedef struct mesh_base
 {
-	mesh_base_id_t id; // The index of the mesh base in it's mesh_bases_t container.
+	MeshBaseId id; // The index of the mesh base in it's MeshBases container.
 
 	int num_faces;
 	int num_positions;
@@ -42,33 +42,33 @@ typedef struct mesh_base
 	CHDS_VEC(int) normal_indices;
     CHDS_VEC(int) uv_indices;
 
-    CHDS_VEC(v3_t) object_space_positions;
-	CHDS_VEC(v3_t) object_space_normals;
-	CHDS_VEC(v2_t) uvs; // TODO: Specifiy for textures?
+    CHDS_VEC(V3) object_space_positions;
+	CHDS_VEC(V3) object_space_normals;
+	CHDS_VEC(V2) uvs; // TODO: Specifiy for textures?
 	
-	v3_t centre;
+	V3 centre;
 
-} mesh_base_t;
+} MeshBase;
 
-// TODO: No longer need this, CHDS_VEC(mesh_base_t)?
+// TODO: No longer need this, CHDS_VEC(MeshBase)?
 typedef struct
 {
-	mesh_base_t* bases;
+	MeshBase* bases;
 	int count;
-} mesh_bases_t;
+} MeshBases;
 
 // Helpers
 void parse_obj_counts(FILE* file, int* num_positions, int* num_uvs, int* num_normals, int* num_faces);
 
-// mesh_base_t API
-status_t mesh_base_init(mesh_base_t* mb);
-status_t mesh_base_from_obj(mesh_base_t* mb, const char* filename);
-void mesh_base_destroy(mesh_base_t* mb);
+// MeshBase API
+Status mesh_base_init(MeshBase* mb);
+Status mesh_base_from_obj(MeshBase* mb, const char* filename);
+void mesh_base_destroy(MeshBase* mb);
 
-// mesh_bases_t API
-status_t mesh_bases_init(mesh_bases_t* mbs);
-mesh_base_id_t mesh_bases_add(mesh_bases_t* mbs);
-void mesh_bases_destroy(mesh_bases_t* mbs);
+// MeshBases API
+Status mesh_bases_init(MeshBases* mbs);
+MeshBaseId mesh_bases_add(MeshBases* mbs);
+void mesh_bases_destroy(MeshBases* mbs);
 
 #endif
  

--- a/engine/engine/core/mesh_instance.c
+++ b/engine/engine/core/mesh_instance.c
@@ -7,19 +7,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-status_t mesh_instance_init(mesh_instance_t* mi, const mesh_base_t* mb)
+Status mesh_instance_init(MeshInstance* mi, const MeshBase* mb)
 {
-	memset(mi, 0, sizeof(mesh_instance_t));
+	memset(mi, 0, sizeof(MeshInstance));
 
 	mi->has_scale_changed = 1; // TODO: Rename to recalc bounding sphere?
     mi->texture_id = -1; // Default to untextured.
 
-    status_t status = mesh_instance_set_base(mi, mb);
+    Status status = mesh_instance_set_base(mi, mb);
 
 	return status;
 }
 
-status_t mesh_instance_set_base(mesh_instance_t* mi, const mesh_base_t* mb)
+Status mesh_instance_set_base(MeshInstance* mi, const MeshBase* mb)
 {
 	// Grow the vertex albedos buffer, there should be one albedo
 	// per vertex.
@@ -34,12 +34,12 @@ status_t mesh_instance_set_base(mesh_instance_t* mi, const mesh_base_t* mb)
 	mi->mb_id = mb->id;
 
 	// Default albedo to white.
-	mesh_instance_set_albedo(mi, mb, (v3_t) { 1.f, 1.f, 1.f });
+	mesh_instance_set_albedo(mi, mb, (V3) { 1.f, 1.f, 1.f });
 	
 	return STATUS_OK;
 }
 
-void mesh_instance_set_albedo(mesh_instance_t* mi, const mesh_base_t* mb, v3_t albedo)
+void mesh_instance_set_albedo(MeshInstance* mi, const MeshBase* mb, V3 albedo)
 {
 	for (int i = 0; i < mb->num_faces * STRIDE_FACE_VERTICES; ++i)
 	{
@@ -49,7 +49,7 @@ void mesh_instance_set_albedo(mesh_instance_t* mi, const mesh_base_t* mb, v3_t a
 	}
 }
 
-void mesh_instance_destroy(mesh_instance_t* mi)
+void mesh_instance_destroy(MeshInstance* mi)
 {
     if (!mi) return;
 

--- a/engine/engine/core/mesh_instance.h
+++ b/engine/engine/core/mesh_instance.h
@@ -26,11 +26,11 @@ TODO: Comments about how this is a component now.
 
 
 // TODO: Do we need this.
-typedef int mesh_instance_id_t; 
+typedef int MeshInstanceId; 
 
 typedef struct mesh_instance
 {
-	mesh_base_id_t mb_id; // TODO: Rename as base?
+	MeshBaseId mb_id; // TODO: Rename as base?
 	int texture_id;
 
     // TODO: How do we ensure that this is set????
@@ -39,14 +39,14 @@ typedef struct mesh_instance
 	// Per instance data
 	// TODO: Do we actually want per vertex albedos? I reckon per face at least
 	//		 makes more sense.
-    // TODO: Float or v3_t???
-	CHDS_VEC(v3_t) vertex_alebdos;
+    // TODO: Float or V3???
+	CHDS_VEC(V3) vertex_alebdos;
 
     // TODO: A scene could have a base ambient light, but mesh instances should also be able to!
     //       This will let them glow. This could potentially be per vertex but probably not worth.
 
-	// Offsets into frame_data_t, these exist here as they are tied
-	// to the mesh_instance_t itself.
+	// Offsets into FrameData, these exist here as they are tied
+	// to the MeshInstance itself.
 
     // TODO: When refactored to component would we have these? probs fine.
 	int view_space_positions_offset;
@@ -54,15 +54,15 @@ typedef struct mesh_instance
 
 	int num_front_faces;
 
-    bounding_sphere_t view_space_bounding_sphere; // Broad phase frustum culling.
+    BoundingSphere view_space_bounding_sphere; // Broad phase frustum culling.
 
-} mesh_instance_t;
+} MeshInstance;
 
-// mesh_instance_t API
-status_t mesh_instance_init(mesh_instance_t* mi, const mesh_base_t* mb);
-void mesh_instance_destroy(mesh_instance_t* mi);
+// MeshInstance API
+Status mesh_instance_init(MeshInstance* mi, const MeshBase* mb);
+void mesh_instance_destroy(MeshInstance* mi);
 
-status_t mesh_instance_set_base(mesh_instance_t* mi, const mesh_base_t* mb);
-void mesh_instance_set_albedo(mesh_instance_t* mi, const mesh_base_t* mb, v3_t albedo);
+Status mesh_instance_set_base(MeshInstance* mi, const MeshBase* mb);
+void mesh_instance_set_albedo(MeshInstance* mi, const MeshBase* mb, V3 albedo);
 
 #endif

--- a/engine/engine/core/resources.h
+++ b/engine/engine/core/resources.h
@@ -14,24 +14,24 @@
 #if 1
 typedef struct
 {
-	texture_t* textures;
+	Texture* textures;
 	int textures_count;
 
-} resources_t;
+} Resources;
 
-inline void resources_init(resources_t* resources)
+inline void resources_init(Resources* resources)
 {
-	memset(resources, 0, sizeof(resources_t));
+	memset(resources, 0, sizeof(Resources));
 }
 
 // TODO: This could return some TextureID that can be used for indexing the texture.
-inline status_t resources_load_texture(resources_t* resources, const char* file)
+inline Status resources_load_texture(Resources* resources, const char* file)
 {
 	// Get the texture's index.
 	int i = resources->textures_count;
 
 	// Make room for the new texture.
-	texture_t* textures_temp = realloc(resources->textures, (size_t)(resources->textures_count + 1) * sizeof(texture_t));
+	Texture* textures_temp = realloc(resources->textures, (size_t)(resources->textures_count + 1) * sizeof(Texture));
 	if (!textures_temp)
 	{
 		log_error("Failed to grow textures array in resources_load_texture because of %s.\n", status_to_str(STATUS_ALLOC_FAILURE));
@@ -40,7 +40,7 @@ inline status_t resources_load_texture(resources_t* resources, const char* file)
 	resources->textures = textures_temp;
 
 	// Try load the texture.
-	status_t status = texture_load_from_bmp(&textures_temp[i], file);
+	Status status = texture_load_from_bmp(&textures_temp[i], file);
 	if (STATUS_OK != status)
 	{
 		log_error("Failed to texture_load_from_bmp in resources_load_texture because of %s.\n", status_to_str(status));
@@ -56,23 +56,23 @@ inline status_t resources_load_texture(resources_t* resources, const char* file)
 #else
 typedef struct
 {
-	canvas_t* textures;
+	Canvas* textures;
 	int textures_count;
 
-} resources_t;
+} Resources;
 
-inline void resources_init(resources_t* resources)
+inline void resources_init(Resources* resources)
 {
-	memset(resources, 0, sizeof(resources_t));
+	memset(resources, 0, sizeof(Resources));
 }
 
-inline status_t resources_load_texture(resources_t* resources, const char* file)
+inline Status resources_load_texture(Resources* resources, const char* file)
 {
 	// Get the texture's index.
 	int i = resources->textures_count;
 
 	// Make room for the new texture.
-	canvas_t* textures_temp = realloc(resources->textures, (size_t)(resources->textures_count + 1) * sizeof(canvas_t));
+	Canvas* textures_temp = realloc(resources->textures, (size_t)(resources->textures_count + 1) * sizeof(Canvas));
 	if (!textures_temp)
 	{
 		log_error("Failed to grow textures array in resources_load_texture because of %s.\n", status_to_str(STATUS_ALLOC_FAILURE));
@@ -81,7 +81,7 @@ inline status_t resources_load_texture(resources_t* resources, const char* file)
 	resources->textures = textures_temp;
 
 	// Try load the texture.
-	status_t status = canvas_init_from_bitmap(&textures_temp[i], file);
+	Status status = canvas_init_from_bitmap(&textures_temp[i], file);
 	if (STATUS_OK != status)
 	{
 		log_error("Failed to canvas_init_from_bitmap in resources_load_texture because of %s.\n", status_to_str(status));

--- a/engine/engine/core/scene.c
+++ b/engine/engine/core/scene.c
@@ -4,9 +4,9 @@
 
 #include <string.h>
 
-status_t scene_init(scene_t* scene)
+Status scene_init(Scene* scene)
 {
-	memset(scene, 0, sizeof(scene_t));
+	memset(scene, 0, sizeof(Scene));
 
 	mesh_bases_init(&scene->mesh_bases);
 
@@ -17,14 +17,14 @@ status_t scene_init(scene_t* scene)
 	return STATUS_OK;
 }
 
-status_t scene_destroy(scene_t* scene)
+Status scene_destroy(Scene* scene)
 {
 	// TODO: Cleanup
 	log_warn("Need to implement scene_destroy.");
 	return STATUS_OK;
 }
 
-mesh_base_id_t scene_add_mesh_base(scene_t* scene)
+MeshBaseId scene_add_mesh_base(Scene* scene)
 {
 	return mesh_bases_add(&scene->mesh_bases);
 }

--- a/engine/engine/core/scene.h
+++ b/engine/engine/core/scene.h
@@ -11,22 +11,22 @@
 // TODO: This should more be storing metadata of the scene, the ecs contains lights and instances etc.
 typedef struct scene
 {
-	mesh_bases_t mesh_bases; // TODO: Should these simply be global? 
+	MeshBases mesh_bases; // TODO: Should these simply be global? 
                           // TODO: Make chds_vec
 
     // TODO: A scene could have a base ambient light, but mesh instances should also be able to!
     //       This will let them glow. This could potentially be per vertex but probably not worth.
-	v3_t ambient_light;
+	V3 ambient_light;
     int bg_colour;
 
-} scene_t;
+} Scene;
 
 // TODO: refactor to remove the 
 
-status_t scene_init(scene_t* scene);
-status_t scene_destroy(scene_t* scene);
+Status scene_init(Scene* scene);
+Status scene_destroy(Scene* scene);
 
-// mesh_base_t API Wrappers
-mesh_base_id_t scene_add_mesh_base(scene_t* scene);
+// MeshBase API Wrappers
+MeshBaseId scene_add_mesh_base(Scene* scene);
 
 #endif

--- a/engine/engine/core/strides.h
+++ b/engine/engine/core/strides.h
@@ -67,7 +67,7 @@ to the buffer to clip.
 
 #define STRIDE_VISIBLE_VERTEX 14
 
-// Front faces need a pos (v3_t), UV (v2_t), normal (v3_t), albedo (v3_t), diffuse (v3_t)
+// Front faces need a pos (V3), UV (V2), normal (V3), albedo (V3), diffuse (V3)
 // as well as the space for light space coordinates.......
 #define STRIDE_BASE_FRONT_VERTEX 14
 #define STRIDE_BASE_FRONT_FACE (STRIDE_BASE_FRONT_VERTEX * STRIDE_FACE_VERTICES)

--- a/engine/engine/core/transform.h
+++ b/engine/engine/core/transform.h
@@ -7,23 +7,23 @@
 
 typedef struct transform
 {
-    v3_t position;
-    v3_t scale;
-    v3_t rotation;
+    V3 position;
+    V3 scale;
+    V3 rotation;
 
     // Store previous state for lerp between state updated by physics.
-    v3_t previous_position;
-    v3_t previous_rotation;
-    //v3_t previous_scale;
+    V3 previous_position;
+    V3 previous_rotation;
+    //V3 previous_scale;
 
-} transform_t;
+} Transform;
 
 
-inline void transform_init(transform_t* t)
+inline void transform_init(Transform* t)
 {
-    t->position = (v3_t){ 0.f, 0.f, 0.f };
-    t->scale = (v3_t){ 1.f, 1.f, 1.f };
-    t->rotation = (v3_t){ 0.f, 0.f, 0.f };
+    t->position = (V3){ 0.f, 0.f, 0.f };
+    t->scale = (V3){ 1.f, 1.f, 1.f };
+    t->rotation = (V3){ 0.f, 0.f, 0.f };
 
     t->previous_position = t->position;
     t->previous_rotation = t->rotation;

--- a/engine/engine/core/window.c
+++ b/engine/engine/core/window.c
@@ -17,7 +17,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // Recover the window pointer.
         LPCREATESTRUCT lpcs = (LPCREATESTRUCT)lParam;
-        window_t* window = (window_t*)lpcs->lpCreateParams;
+        Window* window = (Window*)lpcs->lpCreateParams;
 
         if (!window)
         {
@@ -35,7 +35,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
     case WM_EXITSIZEMOVE:
     {
-        window_t* window = (window_t*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
+        Window* window = (Window*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
 
         // Calculate the new window dimensions.
         RECT rect;
@@ -62,7 +62,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
     case WM_KEYUP:
     {
-        window_t* window = (window_t*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
+        Window* window = (Window*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
         window->on_keyup(window->ctx, wParam);
 
         break;
@@ -76,7 +76,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         // Use raw input for the mouse, so that we don't have to 
         // reset the mouse position every frame as this consistently
         // took about 1ms, wayyyy too long.
-        window_t* window = (window_t*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
+        Window* window = (Window*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
 
         UINT dwSize = 0;
         
@@ -106,7 +106,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
     case WM_LBUTTONDOWN:
     {
-        window_t* window = (window_t*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
+        Window* window = (Window*)GetWindowLongPtrA(hwnd, GWLP_USERDATA);
         window->on_lmbdown(window->ctx);
         break;
     }
@@ -115,10 +115,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
-status_t window_init(window_t* window, canvas_t* canvas, void* ctx, int width, int height)
+Status window_init(Window* window, Canvas* canvas, void* ctx, int width, int height)
 {
 	log_info("Initialising the window.");
-	memset(window, 0, sizeof(window_t));
+	memset(window, 0, sizeof(Window));
 
     window->canvas = canvas;
     window->ctx = ctx;
@@ -165,9 +165,9 @@ status_t window_init(window_t* window, canvas_t* canvas, void* ctx, int width, i
 
     // Create the window
     window->hwnd = CreateWindowExA(
-        0,                          // window_t styles, TODO: PASS window_style?
-        CSRGE_WND_CLASS,         // window_t class
-        CSRGE_WND_TITLE,         // window_t caption
+        0,                          // Window styles, TODO: PASS window_style?
+        CSRGE_WND_CLASS,         // Window class
+        CSRGE_WND_TITLE,         // Window caption
         window_style,
 
         // Size and position
@@ -240,7 +240,7 @@ int window_process_messages()
     return TRUE;
 }
 
-void window_display(window_t* window)
+void window_display(Window* window)
 {
     // TODO: I feel like i need the backbuffer swap for fps lower than refresh rate??
 
@@ -287,7 +287,7 @@ void window_display(window_t* window)
     }
 }
 
-void window_destroy(window_t* window)
+void window_destroy(Window* window)
 {
     // TODO: Not sure how necessary this is.
     //DestroyWindow(window->hwnd);

--- a/engine/engine/core/window.h
+++ b/engine/engine/core/window.h
@@ -19,14 +19,14 @@
 
 // TODO: Top of file comments.
 
-// window_t message handling.
+// Window message handling.
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 int window_process_messages();
 
 typedef struct
 {
-	canvas_t* canvas;
+	Canvas* canvas;
 	
 	HWND hwnd;
 	HDC hdc;
@@ -36,7 +36,7 @@ typedef struct
 	int height;
 
 	// Event callbacks
-	void* ctx; // Set to engine_t* so we can use it in the callbacks.
+	void* ctx; // Set to Engine* so we can use it in the callbacks.
 	void (*on_resize)(void*);
 	void (*on_keyup)(void*, WPARAM);
 	void (*on_lmbdown)(void*);
@@ -47,13 +47,13 @@ typedef struct
     // Keyboard state
     BYTE keys[256];
 	
-} window_t;
+} Window;
 
-status_t window_init(window_t* window, canvas_t* canvas, void* ctx, int width, int height);
+Status window_init(Window* window, Canvas* canvas, void* ctx, int width, int height);
 
-void window_display(window_t* window);
+void window_display(Window* window);
 
-void window_destroy(window_t* window);
+void window_destroy(Window* window);
 
 
 #endif

--- a/engine/engine/maths/bounding_sphere.h
+++ b/engine/engine/maths/bounding_sphere.h
@@ -5,9 +5,9 @@
 
 typedef struct bounding_sphere
 {
-    v3_t centre;
+    V3 centre;
     float radius;
 
-} bounding_sphere_t;
+} BoundingSphere;
 
 #endif

--- a/engine/engine/maths/matrix4.c
+++ b/engine/engine/maths/matrix4.c
@@ -2,7 +2,7 @@
 
 #include "utils.h"
 
-void m4_mul_m4(const m4_t m0, const m4_t m1, m4_t out)
+void m4_mul_m4(const M4 m0, const M4 m1, M4 out)
 {
 	// Post-multiplication, this means the combined out 
 	// matrix will first apply m1, then m0.
@@ -34,7 +34,7 @@ void m4_mul_m4(const m4_t m0, const m4_t m1, m4_t out)
 
 // TODO: Rename out? Any performance critical code 
 //		 can't be returning, takes too long.
-void m4_mul_v4(const m4_t m, v4_t v, v4_t* out)
+void m4_mul_v4(const M4 m, V4 v, V4* out)
 {
 	out->x = m[0] * v.x + m[4] * v.y + m[8] * v.z + m[12] * v.w;
 	out->y = m[1] * v.x + m[5] * v.y + m[9] * v.z + m[13] * v.w;
@@ -42,7 +42,7 @@ void m4_mul_v4(const m4_t m, v4_t v, v4_t* out)
 	out->w = m[3] * v.x + m[7] * v.y + m[11] * v.z + m[15] * v.w;
 }
 
-void m4_identity(m4_t out)
+void m4_identity(M4 out)
 {
 	out[0] = 1;
 	out[1] = 0;
@@ -63,7 +63,7 @@ void m4_identity(m4_t out)
 }
 
 // TODO: Order of in/out?
-void m4_translation(v3_t position, m4_t out)
+void m4_translation(V3 position, M4 out)
 {
 	m4_identity(out);
 	out[12] = position.x;
@@ -71,7 +71,7 @@ void m4_translation(v3_t position, m4_t out)
 	out[14] = position.z;
 }
 
-void m4_rotation(const float pitch, const float yaw, const float roll, m4_t out)
+void m4_rotation(const float pitch, const float yaw, const float roll, M4 out)
 {
 	// TODO: Look into quarternions. https://en.wikipedia.org/wiki/Quaternion
 
@@ -89,7 +89,7 @@ void m4_rotation(const float pitch, const float yaw, const float roll, m4_t out)
 	// TODO: I think labelling these as rotations around axis would make more sense tbf.
 
 	// Rotation around the x axis.
-	m4_t pitch_rot;
+	M4 pitch_rot;
 	m4_identity(pitch_rot);
 
 	pitch_rot[5] = cosPitch;
@@ -98,7 +98,7 @@ void m4_rotation(const float pitch, const float yaw, const float roll, m4_t out)
 	pitch_rot[10] = cosPitch;
 
 	// Rotation around the y axis.
-	m4_t yaw_rot;
+	M4 yaw_rot;
 	m4_identity(yaw_rot);
 	
 	yaw_rot[0] = cosYaw;
@@ -107,7 +107,7 @@ void m4_rotation(const float pitch, const float yaw, const float roll, m4_t out)
 	yaw_rot[10] = cosYaw;
 
 	// Rotation around the z axis.
-	m4_t roll_rot;
+	M4 roll_rot;
 	m4_identity(roll_rot);
 
 	roll_rot[0] = cosRoll;
@@ -127,7 +127,7 @@ void m4_rotation(const float pitch, const float yaw, const float roll, m4_t out)
 	//		 order of matrix multplications a bit better.
 }
 
-void look_at(v3_t position, v3_t direction, m4_t out)
+void look_at(V3 position, V3 direction, M4 out)
 {
 	// TODO: This isn't quite right, most look_at matrices take to and from positions,
 	//		 then the camera would get set to the from position. 
@@ -135,14 +135,14 @@ void look_at(v3_t position, v3_t direction, m4_t out)
 	//		 matrix from a position and direction.
 
 
-	v3_t world_up = { 0, 1, 0 };
+	V3 world_up = { 0, 1, 0 };
 
-	v3_t x_axis;
+	V3 x_axis;
 	if (fabsf(direction.y) == fabsf(world_up.y))
 	{
 		// If direction.y == -1, the cross product will return 0,0,0. 
 		// So hardcode the x axis to the world right?
-		x_axis = (v3_t){ 1,0,0 };
+		x_axis = (V3){ 1,0,0 };
 	}
 	else
 	{
@@ -150,7 +150,7 @@ void look_at(v3_t position, v3_t direction, m4_t out)
 		x_axis = v3_normalised(cross(world_up, direction));
 	}
 
-	v3_t y_axis = cross(direction, x_axis);
+	V3 y_axis = cross(direction, x_axis);
 
 	// Set the out matrix to the combined translation and rotation matrix.
 	m4_identity(out);
@@ -164,20 +164,20 @@ void look_at(v3_t position, v3_t direction, m4_t out)
 	out[14] = dot(direction, position);
 }
 
-void m4_model_matrix(v3_t position, v3_t eulers, v3_t scale, m4_t out)
+void m4_model_matrix(V3 position, V3 eulers, V3 scale, M4 out)
 {
 	// TODO: Eventually gonna switch to quarternions for rotations.
 
 	// TODO: Look into avoiding the matrix multiplications? Can I set translation without multiplying?
 	//		 Pretty sure I can.
 	
-	m4_t translation_m4;
+	M4 translation_m4;
 	m4_translation(position, translation_m4);
 
-	m4_t rotation_m4;
+	M4 rotation_m4;
 	m4_rotation(eulers.x, eulers.y, eulers.z, rotation_m4);
 	
-	m4_t scale_m4;
+	M4 scale_m4;
 	m4_identity(scale_m4);
 	scale_m4[0] = scale.x;
 	scale_m4[5] = scale.y;
@@ -186,7 +186,7 @@ void m4_model_matrix(v3_t position, v3_t eulers, v3_t scale, m4_t out)
 
 	// We have to define an output matrix each time.
 	// Although in my opinion this is fine it makes it more clear.
-	m4_t translation_rotation_m4;
+	M4 translation_rotation_m4;
 
 	// We use post-matrix multiplication, so here, we end up
 	// scaling, then rotating, then translating.
@@ -194,14 +194,14 @@ void m4_model_matrix(v3_t position, v3_t eulers, v3_t scale, m4_t out)
 	m4_mul_m4(translation_rotation_m4, scale_m4, out);
 }
 
-void m4_normal_matrix(v3_t eulers, v3_t scale, m4_t out)
+void m4_normal_matrix(V3 eulers, V3 scale, M4 out)
 {
 	// Create a normal matrix from the given eulers and scale.
 	// Essentially no translation, keep the rotation, and inverse scale.
-	m4_t rotation_m4;
+	M4 rotation_m4;
 	m4_rotation(eulers.x, eulers.y, eulers.z, rotation_m4);
 
-	m4_t scale_m4;
+	M4 scale_m4;
 	m4_identity(scale_m4);
 	scale_m4[0] = 1.f / scale.x;
 	scale_m4[5] = 1.f / scale.y;
@@ -211,7 +211,7 @@ void m4_normal_matrix(v3_t eulers, v3_t scale, m4_t out)
 }
 
 
-void m4_transposed(const m4_t in, m4_t out)
+void m4_transposed(const M4 in, M4 out)
 {
 	// Flip the matrix along the diagonal. Essentially column major to row major.
 	out[0] = in[0];
@@ -232,7 +232,7 @@ void m4_transposed(const m4_t in, m4_t out)
 	out[15] = in[15];
 }
 
-void m4_copy_m3(const m4_t in, m4_t out)
+void m4_copy_m3(const M4 in, M4 out)
 {
 	// TODO: Rename better? Like specific it takes the rotation ??? 
 	// or something about it overwritting the other values
@@ -260,7 +260,7 @@ void m4_copy_m3(const m4_t in, m4_t out)
 	out[15] = 1; // TODO: Not sure about this
 }
 
-void m4_projection(float fov, float aspect_ratio, float near_plane, float far_plane, m4_t out)
+void m4_projection(float fov, float aspect_ratio, float near_plane, float far_plane, M4 out)
 {
 	// TODO: Fov is vertical fov here.
 	// TODO: Comment all this properly to show I actually understand it all.
@@ -288,7 +288,7 @@ void m4_projection(float fov, float aspect_ratio, float near_plane, float far_pl
 	out[15] = 0;
 }
 
-char* m4_to_str(const m4_t m)
+char* m4_to_str(const M4 m)
 {
 	return format_str("%f %f %f %f\n%f %f %f %f\n%f %f %f %f\n%f %f %f %f",
 		m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15]);

--- a/engine/engine/maths/matrix4.h
+++ b/engine/engine/maths/matrix4.h
@@ -25,31 +25,31 @@ in the first matrix much match the rows in the second.
 		 Not sure it even matters. Can be a refactor in future if necessary.
 
 */
-typedef float m4_t[16];
+typedef float M4[16];
 
 // TODO: Rename _out?
-void m4_mul_m4(const m4_t m0, const m4_t m1, m4_t out);
+void m4_mul_m4(const M4 m0, const M4 m1, M4 out);
 
-void m4_mul_v4(const m4_t m, v4_t v, v4_t* out);
+void m4_mul_v4(const M4 m, V4 v, V4* out);
 
-void m4_identity(m4_t out);
+void m4_identity(M4 out);
 
-void m4_translation(v3_t position, m4_t out);
+void m4_translation(V3 position, M4 out);
 
-void m4_rotation(float pitch, float yaw, float roll, m4_t out);
+void m4_rotation(float pitch, float yaw, float roll, M4 out);
 
-void look_at(v3_t position, v3_t direction, m4_t out);
+void look_at(V3 position, V3 direction, M4 out);
 
-void m4_model_matrix(v3_t position, v3_t eulers, v3_t scale, m4_t out);
+void m4_model_matrix(V3 position, V3 eulers, V3 scale, M4 out);
 
-void m4_normal_matrix(v3_t eulers, v3_t scale, m4_t out);
+void m4_normal_matrix(V3 eulers, V3 scale, M4 out);
 
-void m4_transposed(const m4_t in, m4_t out);
+void m4_transposed(const M4 in, M4 out);
 
-void m4_copy_m3(const m4_t in, m4_t out);
+void m4_copy_m3(const M4 in, M4 out);
 
-void m4_projection(float fov, float aspect_ratio, float near_plane, float far_plane, m4_t out);
+void m4_projection(float fov, float aspect_ratio, float near_plane, float far_plane, M4 out);
 
-char* m4_to_str(const m4_t m);
+char* m4_to_str(const M4 m);
 
 #endif

--- a/engine/engine/maths/plane.c
+++ b/engine/engine/maths/plane.c
@@ -6,16 +6,16 @@
 
 // TODO: Doesn't need to be passed by pointer but i think old code using it 
 //       has ptrs already.
-float signed_distance(const plane_t* plane, const v3_t point)
+float signed_distance(const Plane* plane, const V3 point)
 {
 	float d = -dot(plane->normal, plane->point);
 	return dot(point, plane->normal) + d;
 }
 
-float line_intersect_plane(const v3_t v0, const v3_t v1, const plane_t* plane, v3_t* out)
+float line_intersect_plane(const V3 v0, const V3 v1, const Plane* plane, V3* out)
 {
 	// This uses the fact that a plane can be expressed as the set of points p for which Dot((p - p0), n) = 0
-	v3_t ray = v3_sub_v3(v1, v0);
+	V3 ray = v3_sub_v3(v1, v0);
 
 	float normalDotRay = dot(plane->normal, ray);
 
@@ -29,7 +29,7 @@ float line_intersect_plane(const v3_t v0, const v3_t v1, const plane_t* plane, v
 		return 0;
 	}
 
-	v3_t v0_to_plane_point = v3_sub_v3(v0, plane->point);
+	V3 v0_to_plane_point = v3_sub_v3(v0, plane->point);
 
 	// Calculate the time of intersection.
 	float t = -(dot(plane->normal, v0_to_plane_point)) / normalDotRay;
@@ -41,9 +41,9 @@ float line_intersect_plane(const v3_t v0, const v3_t v1, const plane_t* plane, v
 	return t;
 }
 
-plane_t plane_from_points(const v3_t v0, const v3_t v1, const v3_t v2)
+Plane plane_from_points(const V3 v0, const V3 v1, const V3 v2)
 {
-    return (plane_t) {
+    return (Plane) {
         .normal = v3_normalised(cross(v3_sub_v3(v1, v0), v3_sub_v3(v2, v0))),
         .point = v1
     };

--- a/engine/engine/maths/plane.h
+++ b/engine/engine/maths/plane.h
@@ -5,15 +5,15 @@
 
 typedef struct
 {
-	v3_t normal;
-	v3_t point;
-} plane_t;
+	V3 normal;
+	V3 point;
+} Plane;
 
 
-float signed_distance(const plane_t* plane, const v3_t point);
+float signed_distance(const Plane* plane, const V3 point);
 
-float line_intersect_plane(const v3_t v0, const v3_t v1, const plane_t* plane, v3_t* out);
+float line_intersect_plane(const V3 v0, const V3 v1, const Plane* plane, V3* out);
 
-plane_t plane_from_points(const v3_t v0, const v3_t v1, const v3_t v2);
+Plane plane_from_points(const V3 v0, const V3 v1, const V3 v2);
 
 #endif

--- a/engine/engine/maths/utils.h
+++ b/engine/engine/maths/utils.h
@@ -20,7 +20,7 @@ inline float lerp(float a, float b, float t)
 }
 
 
-inline void direction_to_eulers(const v3_t direction, float* pitch, float* yaw)
+inline void direction_to_eulers(const V3 direction, float* pitch, float* yaw)
 {
 	// Converts a direction to its euler angles, roll is 0 for a direction.
 

--- a/engine/engine/maths/vector2.h
+++ b/engine/engine/maths/vector2.h
@@ -5,26 +5,26 @@ typedef struct
 {
 	float x, y;
 
-} v2_t;
+} V2;
 
-inline v2_t v2_add_v2(v2_t v0, v2_t v1)
+inline V2 v2_add_v2(V2 v0, V2 v1)
 {
-    return (v2_t) { v0.x + v1.x, v0.y + v1.y };
+    return (V2) { v0.x + v1.x, v0.y + v1.y };
 }
 
-inline v2_t v2_sub_v2(v2_t v0, v2_t v1)
+inline V2 v2_sub_v2(V2 v0, V2 v1)
 {
-    return (v2_t) { v0.x - v1.x, v0.y - v1.y };
+    return (V2) { v0.x - v1.x, v0.y - v1.y };
 }
 
-inline v2_t v2_mul_f(v2_t v, float f)
+inline V2 v2_mul_f(V2 v, float f)
 {
-    return (v2_t) { v.x * f, v.y * f };
+    return (V2) { v.x * f, v.y * f };
 }
 
-inline v2_t v2_read(const float* in)
+inline V2 v2_read(const float* in)
 {
-	return (v2_t) { in[0], in[1] };
+	return (V2) { in[0], in[1] };
 }
 
 #endif

--- a/engine/engine/maths/vector3.h
+++ b/engine/engine/maths/vector3.h
@@ -14,7 +14,7 @@ difference, most likely because they compile to the same thing.
 Also, we pass these by value which should result in better performance for a small struct,
 see: https://austinmorlan.com/posts/pass_by_value_vs_pointer/#:~:text=When%20I%20was%20in%20college,of%20that%20on%20the%20stack
 
-Returning the v3_t seems to have no performance impact and makes the code much more readable.
+Returning the V3 seems to have no performance impact and makes the code much more readable.
 
 No need to overcomplicate this stuff, I can always do it differently in a per-pixel loop if
 profiling shows this is an issue.
@@ -24,25 +24,25 @@ typedef struct v3
 {
 	float x, y, z;
 
-} v3_t;
+} V3;
 
-inline v3_t cross(v3_t v0, v3_t v1)
+inline V3 cross(V3 v0, V3 v1)
 {
-	return (v3_t) { v0.y * v1.z - v0.z * v1.y, v0.z * v1.x - v0.x * v1.z, v0.x * v1.y - v0.y * v1.x };
+	return (V3) { v0.y * v1.z - v0.z * v1.y, v0.z * v1.x - v0.x * v1.z, v0.x * v1.y - v0.y * v1.x };
 }
 
 // TODO: Rename v3_size etc?
-inline float v3_size(v3_t v)
+inline float v3_size(V3 v)
 {
 	return sqrtf(v.x * v.x + v.y * v.y + v.z * v.z);
 }
 
-inline float v3_size_sqrd(v3_t v)
+inline float v3_size_sqrd(V3 v)
 {
 	return v.x * v.x + v.y * v.y + v.z * v.z;
 }
 
-inline void v3_normalise(v3_t* v)
+inline void v3_normalise(V3* v)
 {	
 	const float inv_size = 1.f / sqrtf(v->x * v->x + v->y * v->y + v->z * v->z);
 	v->x *= inv_size;
@@ -51,97 +51,97 @@ inline void v3_normalise(v3_t* v)
 }
 
 // TODO: v3_ prefix?
-inline v3_t v3_normalised(v3_t v)
+inline V3 v3_normalised(V3 v)
 {
 	const float inv_size = 1.f / v3_size(v);
 
-	return (v3_t) { v.x * inv_size, v.y * inv_size, v.z * inv_size, };
+	return (V3) { v.x * inv_size, v.y * inv_size, v.z * inv_size, };
 }
 
-inline float dot(v3_t v0, v3_t v1)
+inline float dot(V3 v0, V3 v1)
 {
 	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z;
 }
 
-inline void v3_mul_eq_v3(v3_t* v0, v3_t v1)
+inline void v3_mul_eq_v3(V3* v0, V3 v1)
 {
 	v0->x *= v1.x;
 	v0->y *= v1.y;
 	v0->z *= v1.z;
 }
 
-inline v3_t v3_mul_v3(v3_t v0, v3_t v1)
+inline V3 v3_mul_v3(V3 v0, V3 v1)
 {
-	return (v3_t) { v0.x * v1.x, v0.y * v1.y, v0.z * v1.z };
+	return (V3) { v0.x * v1.x, v0.y * v1.y, v0.z * v1.z };
 }
 
-inline void v3_mul_eq_f(v3_t* v, float f)
+inline void v3_mul_eq_f(V3* v, float f)
 {
 	v->x *= f;
 	v->y *= f;
 	v->z *= f;
 }
 
-inline v3_t v3_mul_f(v3_t v, float f)
+inline V3 v3_mul_f(V3 v, float f)
 {
-	return (v3_t) { v.x * f, v.y * f, v.z * f };
+	return (V3) { v.x * f, v.y * f, v.z * f };
 }
 
-inline void v3_add_eq_f(v3_t* v, float f)
+inline void v3_add_eq_f(V3* v, float f)
 {
 	v->x += f;
 	v->y += f;
 	v->z += f;
 }
 
-inline void v3_add_eq_v3(v3_t* v0, v3_t v1)
+inline void v3_add_eq_v3(V3* v0, V3 v1)
 {
 	v0->x += v1.x;
 	v0->y += v1.y;
 	v0->z += v1.z;
 }
 
-inline v3_t v3_add_v3(v3_t v0, v3_t v1)
+inline V3 v3_add_v3(V3 v0, V3 v1)
 {
-	return (v3_t) { v0.x + v1.x, v0.y + v1.y, v0.z + v1.z };
+	return (V3) { v0.x + v1.x, v0.y + v1.y, v0.z + v1.z };
 }
 
-inline void v3_sub_eq_f(v3_t* v, float f)
+inline void v3_sub_eq_f(V3* v, float f)
 {
 	v->x -= f;
 	v->y -= f;
 	v->z -= f;
 }
 
-inline void v3_sub_eq_v3(v3_t* v0, v3_t v1)
+inline void v3_sub_eq_v3(V3* v0, V3 v1)
 {
 	v0->x -= v1.x;
 	v0->y -= v1.y;
 	v0->z -= v1.z;
 }
 
-inline v3_t v3_sub_v3(v3_t v0, v3_t v1)
+inline V3 v3_sub_v3(V3 v0, V3 v1)
 {
-	return (v3_t) { v0.x - v1.x, v0.y - v1.y, v0.z - v1.z };
+	return (V3) { v0.x - v1.x, v0.y - v1.y, v0.z - v1.z };
 }
 
-inline v3_t v3_uniform(float n)
+inline V3 v3_uniform(float n)
 {
-    return (v3_t) { n, n, n };
+    return (V3) { n, n, n };
 }
 
-inline v3_t v3_inv(v3_t v)
+inline V3 v3_inv(V3 v)
 {
-    return (v3_t) { 1.f / v.x, 1.f / v.y, 1.f / v.z };
+    return (V3) { 1.f / v.x, 1.f / v.y, 1.f / v.z };
 }
 
-inline v3_t v3_lerp(v3_t v0, v3_t v1, float t)
+inline V3 v3_lerp(V3 v0, V3 v1, float t)
 {
     return v3_add_v3(v0, v3_mul_f(v3_sub_v3(v1, v0), t));
 }
 
 /*
-inline void v3_write(float* out, v3_t v)
+inline void v3_write(float* out, V3 v)
 {
 	out[0] = v.x;
 	out[1] = v.y;
@@ -151,19 +151,19 @@ inline void v3_write(float* out, v3_t v)
 
 
 
-inline v3_t v3_read(const float* in)
+inline V3 v3_read(const float* in)
 {
-	return (v3_t) {in[0], in[1], in[2] };
+	return (V3) {in[0], in[1], in[2] };
 }
 
 
-inline char* v3_to_str(v3_t v)
+inline char* v3_to_str(V3 v)
 {
 	return format_str("%f %f %f", v.x, v.y, v.z);
 }
 
 // TODO: This shouldn't be in vector3.h?
-inline int is_front_face(v3_t v0, v3_t v1, v3_t v2)
+inline int is_front_face(V3 v0, V3 v1, V3 v2)
 {
     // Camera is at origin as coordinates are given in view space, so 
     // view vector from tri to cam is V = v0 - P or just -v0

--- a/engine/engine/maths/vector4.h
+++ b/engine/engine/maths/vector4.h
@@ -9,9 +9,9 @@ typedef struct
 {
 	float x, y, z, w;
 
-} v4_t;
+} V4;
 
-inline void v4_mul_eq_v4(v4_t* v0, v4_t v1)
+inline void v4_mul_eq_v4(V4* v0, V4 v1)
 {
 	v0->x *= v1.x;
 	v0->y *= v1.y;
@@ -19,7 +19,7 @@ inline void v4_mul_eq_v4(v4_t* v0, v4_t v1)
 	v0->w *= v1.w;
 }
 
-inline void v4_mul_eq_f(v4_t* v, float f)
+inline void v4_mul_eq_f(V4* v, float f)
 {
 	v->x *= f;
 	v->y *= f;
@@ -27,12 +27,12 @@ inline void v4_mul_eq_f(v4_t* v, float f)
 	v->w *= f;
 }
 
-inline v4_t v4_mul_f(v4_t v, float f)
+inline V4 v4_mul_f(V4 v, float f)
 {
-	return (v4_t) { v.x * f, v.y * f, v.z * f, v.w * f };
+	return (V4) { v.x * f, v.y * f, v.z * f, v.w * f };
 }
 
-inline void v4_add_eq_f(v4_t* v, float f)
+inline void v4_add_eq_f(V4* v, float f)
 {
 	v->x += f;
 	v->y += f;
@@ -40,12 +40,12 @@ inline void v4_add_eq_f(v4_t* v, float f)
 	v->w += f;
 }
 
-inline v4_t v4_add_f(v4_t v, float f)
+inline V4 v4_add_f(V4 v, float f)
 {
-	return (v4_t) { v.x + f, v.y + f, v.z + f, v.w + f };
+	return (V4) { v.x + f, v.y + f, v.z + f, v.w + f };
 }
 
-inline void v4_add_eq_v4(v4_t* v0, v4_t v1)
+inline void v4_add_eq_v4(V4* v0, V4 v1)
 {
 	v0->x += v1.x;
 	v0->y += v1.y;
@@ -53,7 +53,7 @@ inline void v4_add_eq_v4(v4_t* v0, v4_t v1)
 	v0->w += v1.w;
 }
 
-inline void v4_sub_eq_f(v4_t* v, float f)
+inline void v4_sub_eq_f(V4* v, float f)
 {
 	v->x -= f;
 	v->y -= f;
@@ -61,7 +61,7 @@ inline void v4_sub_eq_f(v4_t* v, float f)
 	v->w -= f;
 }
 
-inline void v4_sub_eq_v4(v4_t* v0, v4_t v1)
+inline void v4_sub_eq_v4(V4* v0, V4 v1)
 {
 	v0->x -= v1.x;
 	v0->y -= v1.y;
@@ -69,14 +69,14 @@ inline void v4_sub_eq_v4(v4_t* v0, v4_t v1)
 	v0->w -= v1.w;
 }
 
-inline v4_t v4_sub_v4(v4_t v0, v4_t v1)
+inline V4 v4_sub_v4(V4 v0, V4 v1)
 {
-	return (v4_t) { v0.x - v1.x, v0.y - v1.y, v0.z - v1.z, v0.w - v1.w };
+	return (V4) { v0.x - v1.x, v0.y - v1.y, v0.z - v1.z, v0.w - v1.w };
 }
 
 // TODO: If it turns out these are taking a noticeable amount of CPU,
 //		 convert to #define.
-inline void v4_write(float* out, v4_t v)
+inline void v4_write(float* out, V4 v)
 {
 	out[0] = v.x;
 	out[1] = v.y;
@@ -85,19 +85,19 @@ inline void v4_write(float* out, v4_t v)
 }
 
 // TODO: Feels a little messy
-inline void v4_write_xyz(float* out, v4_t v)
+inline void v4_write_xyz(float* out, V4 v)
 {
 	out[0] = v.x;
 	out[1] = v.y;
 	out[2] = v.z;
 }
 
-inline v4_t v4_read(const float* in)
+inline V4 v4_read(const float* in)
 {
-	return (v4_t) { in[0], in[1], in[2], in[3] };
+	return (V4) { in[0], in[1], in[2], in[3] };
 }
 
-inline char* v4_to_str(v4_t v)
+inline char* v4_to_str(V4 v)
 {
 	return format_str("%f %f %f %f", v.x, v.y, v.z, v.w);
 }

--- a/engine/engine/maths/vector_maths.h
+++ b/engine/engine/maths/vector_maths.h
@@ -9,23 +9,23 @@
 // TODO: Per function comments.
 // Avoid circular dependencies by having shared functions here.
 
-inline v3_t v4_xyz(v4_t v)
+inline V3 v4_xyz(V4 v)
 {
-	return (v3_t) { .x = v.x, v.y, v.z };
+	return (V3) { .x = v.x, v.y, v.z };
 }
 
-inline v4_t v3_to_v4(v3_t in, float w)
+inline V4 v3_to_v4(V3 in, float w)
 {
-	return (v4_t) { in.x, in.y, in.z, w };
+	return (V4) { in.x, in.y, in.z, w };
 }
 
 // Combine these to potentially minimise function calls.
-inline v4_t v3_read_to_v4(const float* in, float w)
+inline V4 v3_read_to_v4(const float* in, float w)
 {
-	return (v4_t) { in[0], in[1], in[2], w };
+	return (V4) { in[0], in[1], in[2], w };
 }
 
-inline uint8_t point_in_triangle(v3_t p, v3_t a, v3_t b, v3_t c)
+inline uint8_t point_in_triangle(V3 p, V3 a, V3 b, V3 c)
 {
     // FROM: https://gdbooks.gitbooks.io/3dcollisions/content/Chapter4/point_in_triangle.html
 
@@ -37,9 +37,9 @@ inline uint8_t point_in_triangle(v3_t p, v3_t a, v3_t b, v3_t c)
 
     // Calculate normals of triangles using two vertices and the 
     // origin (P).
-    v3_t u = cross(b, c); // PBC
-    v3_t v = cross(c, a); // PCA
-    v3_t w = cross(a, b); // PAB
+    V3 u = cross(b, c); // PBC
+    V3 v = cross(c, a); // PCA
+    V3 w = cross(a, b); // PAB
 
     // If all normals face the same direction, then ABC contains P.
     if (dot(u, v) < 0.f) return 0;

--- a/engine/engine/physics/collision.c
+++ b/engine/engine/physics/collision.c
@@ -16,19 +16,19 @@
 
 #include <cecs/ecs.h>
 
-static void update_collision_mesh_bounding_sphere(collider_t* collider, const mesh_instance_t* mi, const transform_t transform)
+static void update_collision_mesh_bounding_sphere(Collider* collider, const MeshInstance* mi, const Transform transform)
 {
-    const mesh_base_t* mb = collider->shape.mesh.mb;
+    const MeshBase* mb = collider->shape.mesh.mb;
 
     CHDS_VEC_RESERVE(collider->shape.mesh.wsps, mb->num_positions);
 
     // Calculate model matrix.
     // TODO: rotation or direction or eulers?
-    m4_t model_matrix;
+    M4 model_matrix;
     m4_model_matrix(transform.position, transform.rotation, transform.scale, model_matrix);
 
     // Update the centre of the bounding sphere.
-    v4_t world_space_centre;
+    V4 world_space_centre;
     m4_mul_v4(
         model_matrix,
         v3_to_v4(mb->centre, 1.f),
@@ -40,8 +40,8 @@ static void update_collision_mesh_bounding_sphere(collider_t* collider, const me
     // Convert object space positions to world space.
     for (int j = 0; j < mb->num_positions; ++j)
     {
-        const v4_t osp = v3_to_v4(mb->object_space_positions[j], 1.f);
-        v4_t wsp;
+        const V4 osp = v3_to_v4(mb->object_space_positions[j], 1.f);
+        V4 wsp;
         m4_mul_v4(model_matrix, osp, &wsp);
 
         collider->shape.mesh.wsps[j].x = wsp.x;
@@ -57,16 +57,16 @@ static void update_collision_mesh_bounding_sphere(collider_t* collider, const me
         return;
     }
 
-    bounding_sphere_t* bs = &collider->shape.bs;
-    v3_t centre = bs->centre;
+    BoundingSphere* bs = &collider->shape.bs;
+    V3 centre = bs->centre;
 
     // Calculate the new radius of the mi's bounding sphere.
     float radius_squared = -1;
 
     for (int j = 0; j < mb->num_positions; ++j)
     {
-        v3_t v = collider->shape.mesh.wsps[j];
-        v3_t between = v3_sub_v3(v, centre);
+        V3 v = collider->shape.mesh.wsps[j];
+        V3 between = v3_sub_v3(v, centre);
 
         radius_squared = max(v3_size_sqrd(between), radius_squared);
     }
@@ -76,21 +76,21 @@ static void update_collision_mesh_bounding_sphere(collider_t* collider, const me
     collider->shape.scale_dirty = 0;
 }
 
-static void update_colliders(physics_t* physics, scene_t* scene)
+static void update_colliders(Physics* physics, Scene* scene)
 {
     // TODO: Eventually we might want specific collision meshes to simplify it?
     // TODO: E.g. we don't need the higher detail meshes to collide with, but not needed for now.
     cecs_view_iter it = cecs_view_iter_create(physics->ecs, physics->colliders_view);
     while (cecs_view_iter_next(&it))
     {
-        const transform_t* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
-        const mesh_instance_t* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
-        collider_t* colliders = cecs_get_column(it, COMPONENT_COLLIDER);
+        const Transform* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
+        const MeshInstance* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
+        Collider* colliders = cecs_get_column(it, COMPONENT_COLLIDER);
 
         // Update world space positions of entity, update centre of bounding sphere.
         for (uint32_t i = 0; i < it.num_entities; ++i)
         {
-            collider_t* collider = &colliders[i];
+            Collider* collider = &colliders[i];
 
             // TODO: Where can we actually set this?????? after appling forces???
             //if (!collider->shape.dirty)
@@ -102,9 +102,9 @@ static void update_colliders(physics_t* physics, scene_t* scene)
             {
             case COLLISION_SHAPE_MESH:
             {
-                const transform_t transform = transforms[i];
-                const mesh_instance_t* mi = &mis[i];
-                const mesh_base_t* mb = &scene->mesh_bases.bases[mi->mb_id];
+                const Transform transform = transforms[i];
+                const MeshInstance* mi = &mis[i];
+                const MeshBase* mb = &scene->mesh_bases.bases[mi->mb_id];
 
                 collider->shape.mesh.mb = mb;
                 update_collision_mesh_bounding_sphere(collider, mi, transform);
@@ -112,7 +112,7 @@ static void update_colliders(physics_t* physics, scene_t* scene)
             }
             case COLLISION_SHAPE_ELLIPSOID:
             {
-                const transform_t transform = transforms[i];
+                const Transform transform = transforms[i];
                 collider->shape.bs.centre = transform.position;
 
                 // TODO: not sure if this is really correct, could do for now.
@@ -130,7 +130,7 @@ static void update_colliders(physics_t* physics, scene_t* scene)
     }
 }
 
-static void broad_phase(physics_t* physics, scene_t* scene)
+static void broad_phase(Physics* physics, Scene* scene)
 {
     // Broad phase is purely bounding sphere tests
     // TODO: not ideal if the narrow phase is a sphere, but obv not an issue for now.
@@ -171,14 +171,14 @@ static void broad_phase(physics_t* physics, scene_t* scene)
     cecs_view_iter it = cecs_view_iter_create(physics->ecs, physics->moving_colliders_view);
     while (cecs_view_iter_next(&it))
     {
-        physics_data_t* physics_datas = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
-        transform_t* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
-        const mesh_instance_t* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
-        const collider_t* colliders = cecs_get_column(it, COMPONENT_COLLIDER);
+        PhysicsData* physics_datas = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
+        Transform* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
+        const MeshInstance* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
+        const Collider* colliders = cecs_get_column(it, COMPONENT_COLLIDER);
 
         for (uint32_t i = 0; i < it.num_entities; ++i)
         {
-            physics_data_t* physics_data = &physics_datas[i];
+            PhysicsData* physics_data = &physics_datas[i];
 
             // TODO: Because of testing only past the current moving entity,
             //       we cannot have this check as it means a static mesh
@@ -192,10 +192,10 @@ static void broad_phase(physics_t* physics, scene_t* scene)
                 continue;
             }*/
 
-            transform_t* transform = &transforms[i];
-            const mesh_instance_t* mi = &mis[i];
-            const mesh_base_t* mb = &scene->mesh_bases.bases[mi->mb_id];
-            const collider_t* collider = &colliders[i];
+            Transform* transform = &transforms[i];
+            const MeshInstance* mi = &mis[i];
+            const MeshBase* mb = &scene->mesh_bases.bases[mi->mb_id];
+            const Collider* collider = &colliders[i];
 
             // Iterate from the current entity, will this work????
             // TODO: This might not work if we don't resolve collisions
@@ -206,29 +206,29 @@ static void broad_phase(physics_t* physics, scene_t* scene)
             // Check each remaining moving entity
             do
             {
-                const mesh_instance_t* mis1 = cecs_get_column(it_from_it0, COMPONENT_MESH_INSTANCE);
-                const collider_t* colliders1 = cecs_get_column(it_from_it0, COMPONENT_COLLIDER);
-                physics_data_t* physics_datas1 = cecs_get_column(it_from_it0, COMPONENT_PHYSICS_DATA);
-                transform_t* transforms1 = cecs_get_column(it_from_it0, COMPONENT_TRANSFORM);
+                const MeshInstance* mis1 = cecs_get_column(it_from_it0, COMPONENT_MESH_INSTANCE);
+                const Collider* colliders1 = cecs_get_column(it_from_it0, COMPONENT_COLLIDER);
+                PhysicsData* physics_datas1 = cecs_get_column(it_from_it0, COMPONENT_PHYSICS_DATA);
+                Transform* transforms1 = cecs_get_column(it_from_it0, COMPONENT_TRANSFORM);
 
                 // Start past current entity
                 for (uint32_t j = i + 1; j < it_from_it0.num_entities; ++j)
                 {
-                    const mesh_instance_t* mi1 = &mis1[j];
+                    const MeshInstance* mi1 = &mis1[j];
 
                     // TODO: Cannot collide with self for now, leave this as reminder
                     //       until the logic is validated.
                     // Don't collide with self.
                     //if (mi1 == mi) continue;
 
-                    const collider_t* collider1 = &colliders1[j];
-                    transform_t* transform1 = &transforms1[j];
+                    const Collider* collider1 = &colliders1[j];
+                    Transform* transform1 = &transforms1[j];
 
                     // Account for entity1's velocity.
-                    physics_data_t* physics_data1 = &physics_datas1[j];
+                    PhysicsData* physics_data1 = &physics_datas1[j];
 
-                    bounding_sphere_t bs0 = collider->shape.bs;
-                    const bounding_sphere_t bs1 = collider1->shape.bs;
+                    BoundingSphere bs0 = collider->shape.bs;
+                    const BoundingSphere bs1 = collider1->shape.bs;
 
                     // Test for overlap.
                     const float dist = v3_size_sqrd(v3_sub_v3(bs1.centre, bs0.centre));
@@ -236,7 +236,7 @@ static void broad_phase(physics_t* physics, scene_t* scene)
 
                     if (dist <= n)
                     {
-                        potential_collision_t pc = {
+                        PotentialCollision pc = {
                             .c0 = collider,
                             .mi0 = mi,
                             .pd0 = physics_data,
@@ -258,19 +258,19 @@ static void broad_phase(physics_t* physics, scene_t* scene)
 
             while (cecs_view_iter_next(&sc_it))
             {
-                const mesh_instance_t* mis1 = cecs_get_column(sc_it, COMPONENT_MESH_INSTANCE);
-                const collider_t* colliders1 = cecs_get_column(sc_it, COMPONENT_COLLIDER);
-                const transform_t* transforms1 = cecs_get_column(sc_it, COMPONENT_TRANSFORM);
+                const MeshInstance* mis1 = cecs_get_column(sc_it, COMPONENT_MESH_INSTANCE);
+                const Collider* colliders1 = cecs_get_column(sc_it, COMPONENT_COLLIDER);
+                const Transform* transforms1 = cecs_get_column(sc_it, COMPONENT_TRANSFORM);
 
                 // Start past current entity
                 for (uint32_t j = 0; j < sc_it.num_entities; ++j)
                 {
-                    mesh_instance_t* mi1 = &mis1[j];
-                    const collider_t* collider1 = &colliders1[j];
-                    transform_t* transform1 = &transforms1[j];
+                    MeshInstance* mi1 = &mis1[j];
+                    const Collider* collider1 = &colliders1[j];
+                    Transform* transform1 = &transforms1[j];
 
-                    bounding_sphere_t bs0 = collider->shape.bs;
-                    const bounding_sphere_t bs1 = collider1->shape.bs;
+                    BoundingSphere bs0 = collider->shape.bs;
+                    const BoundingSphere bs1 = collider1->shape.bs;
 
                     // Test for overlap.
                     const float dist = v3_size_sqrd(v3_sub_v3(bs1.centre, bs0.centre));
@@ -278,7 +278,7 @@ static void broad_phase(physics_t* physics, scene_t* scene)
 
                     if (dist <= n)
                     {
-                        potential_collision_t pc = {
+                        PotentialCollision pc = {
                             .c0 = collider,
                             .mi0 = mi,
                             .pd0 = physics_data,
@@ -297,17 +297,17 @@ static void broad_phase(physics_t* physics, scene_t* scene)
     }
 }
 
-static void resolve_single_collision(v3_t collision_normal, float penetration_depth, physics_data_t* a_pd, physics_data_t* b_pd, transform_t* a_t, transform_t* b_t,
+static void resolve_single_collision(V3 collision_normal, float penetration_depth, PhysicsData* a_pd, PhysicsData* b_pd, Transform* a_t, Transform* b_t,
     float e, float mu)
 {
     const float a_mass = a_pd ? a_pd->mass : 0.f;
     const float b_mass = b_pd ? b_pd->mass : 0.f;
 
     // Must recalculate relative velocity here so it is updated from any previous collisions.
-    const v3_t a_vel = a_pd ? a_pd->velocity : v3_uniform(0.f);
-    const v3_t b_vel = b_pd ? b_pd->velocity : v3_uniform(0.f);
+    const V3 a_vel = a_pd ? a_pd->velocity : v3_uniform(0.f);
+    const V3 b_vel = b_pd ? b_pd->velocity : v3_uniform(0.f);
 
-    v3_t rel_vel = v3_sub_v3(a_vel, b_vel);
+    V3 rel_vel = v3_sub_v3(a_vel, b_vel);
     
     // Resolve a collision between objects A and B.
     const float slop = 0; // TODO: Do we want slop? This is actually stopping us from separating fully right????
@@ -325,7 +325,7 @@ static void resolve_single_collision(v3_t collision_normal, float penetration_de
     if (total_inv_mass <= 0.f) return;
 
     // Separate objects.
-    v3_t correction = v3_mul_f(collision_normal, penetration_depth / total_inv_mass);
+    V3 correction = v3_mul_f(collision_normal, penetration_depth / total_inv_mass);
 
     v3_add_eq_v3(&a_t->position, v3_mul_f(correction, a_inv_mass));
     v3_sub_eq_v3(&b_t->position, v3_mul_f(correction, b_inv_mass));
@@ -340,10 +340,10 @@ static void resolve_single_collision(v3_t collision_normal, float penetration_de
     float j = -(1.f + e) * vel_along_n;
     j /= total_inv_mass;
 
-    v3_t normal_impulse = v3_mul_f(collision_normal, j);
+    V3 normal_impulse = v3_mul_f(collision_normal, j);
 
     // Tangential impulse, apply Coulomb friction.
-    v3_t tangent = v3_sub_v3(rel_vel, v3_mul_f(collision_normal, dot(collision_normal, rel_vel)));
+    V3 tangent = v3_sub_v3(rel_vel, v3_mul_f(collision_normal, dot(collision_normal, rel_vel)));
     const float size = v3_size(tangent);
     if (size > 0.f) v3_mul_eq_f(&tangent, 1.f / size);
 
@@ -358,10 +358,10 @@ static void resolve_single_collision(v3_t collision_normal, float penetration_de
     if (jt < -max_friction) jt = -max_friction;
     else if (jt > max_friction) jt = max_friction;
 
-    v3_t friction_impulse = v3_mul_f(tangent, jt);
+    V3 friction_impulse = v3_mul_f(tangent, jt);
 
     // Apply impulses.
-    v3_t total_impulse = v3_add_v3(normal_impulse, friction_impulse);
+    V3 total_impulse = v3_add_v3(normal_impulse, friction_impulse);
 
     if (a_pd)
     {
@@ -383,7 +383,7 @@ static void resolve_single_collision(v3_t collision_normal, float penetration_de
     }*/
 }
 
-static void unit_sphere_tri_edge_collision(v3_t p0, v3_t p1, v3_t centre, uint8_t* collided, v3_t* collision_point, float* penetration_depth)
+static void unit_sphere_tri_edge_collision(V3 p0, V3 p1, V3 centre, uint8_t* collided, V3* collision_point, float* penetration_depth)
 {
     // Essentially performing ray triangle collision but between t0 and t1,
     // the start and ends of the line.
@@ -457,12 +457,12 @@ static void unit_sphere_tri_edge_collision(v3_t p0, v3_t p1, v3_t centre, uint8_
 
     */
 
-    v3_t p1p0 = v3_sub_v3(p1, p0);
+    V3 p1p0 = v3_sub_v3(p1, p0);
     float t = dot(p1p0, v3_sub_v3(centre, p0)) / dot(p1p0, p1p0);
 
     if (t >= 0 && t <= 1)
     {
-        v3_t tmp_collision_point = v3_add_v3(p0, v3_mul_f(p1p0, t));
+        V3 tmp_collision_point = v3_add_v3(p0, v3_mul_f(p1p0, t));
 
         if (v3_size_sqrd(v3_sub_v3(tmp_collision_point, centre)) <= 1.f)
         {
@@ -479,7 +479,7 @@ static void unit_sphere_tri_edge_collision(v3_t p0, v3_t p1, v3_t centre, uint8_
     }
 }
 
-static void unit_sphere_tri_vertex_collision(v3_t p, v3_t centre, uint8_t* collided, v3_t* collision_point, float* penetration_depth)
+static void unit_sphere_tri_vertex_collision(V3 p, V3 centre, uint8_t* collided, V3* collision_point, float* penetration_depth)
 {
     // If distance between vertex and sphere centre is less than radius, we are colliding.
     float d = v3_size_sqrd(v3_sub_v3(p, centre));
@@ -500,7 +500,7 @@ static void unit_sphere_tri_vertex_collision(v3_t p, v3_t centre, uint8_t* colli
     }
 }
 
-static void narrow_ellipsoid_vs_mi(physics_t* physics, scene_t* scene, potential_collision_t pc)
+static void narrow_ellipsoid_vs_mi(Physics* physics, Scene* scene, PotentialCollision pc)
 {
     // Inspired from: https://www.peroxide.dk/papers/collision/collision.pdf
 
@@ -511,31 +511,31 @@ static void narrow_ellipsoid_vs_mi(physics_t* physics, scene_t* scene, potential
     //       Not really sure how to go about that but can solve it when needed? ^^^
     // TODO: Assert in broad phase to ensure this doesn't happen?
 
-    physics_data_t* mi_pd = pc.pd1;
-    transform_t* mi_transform = pc.t1;
-    v3_t mi_vel = mi_pd ? mi_pd->velocity : v3_uniform(0.f);
+    PhysicsData* mi_pd = pc.pd1;
+    Transform* mi_transform = pc.t1;
+    V3 mi_vel = mi_pd ? mi_pd->velocity : v3_uniform(0.f);
 
     // c0 is ellipsoid collider !
-    collider_t* ellipsoid_collider = pc.c0;
-    physics_data_t* ellipsoid_pd = pc.pd0;
-    transform_t* ellipsoid_transform = pc.t0;
-    v3_t e_pos = ellipsoid_transform->position;
+    Collider* ellipsoid_collider = pc.c0;
+    PhysicsData* ellipsoid_pd = pc.pd0;
+    Transform* ellipsoid_transform = pc.t0;
+    V3 e_pos = ellipsoid_transform->position;
 
-    v3_t ellipsoid = ellipsoid_collider->shape.ellipsoid;
-    v3_t inv_ellipsoid = v3_inv(ellipsoid);
+    V3 ellipsoid = ellipsoid_collider->shape.ellipsoid;
+    V3 inv_ellipsoid = v3_inv(ellipsoid);
 
     // TODO: Rename vars and tidy this all up.
 
     // Calculate relative velocity between objects.
-    v3_t vel = v3_sub_v3(ellipsoid_pd->velocity, mi_vel);
+    V3 vel = v3_sub_v3(ellipsoid_pd->velocity, mi_vel);
 
-    v3_t e_start_pos = e_pos;
+    V3 e_start_pos = e_pos;
     v3_mul_eq_v3(&e_start_pos, inv_ellipsoid);
 
-    collider_t* mi_collider = pc.c1;
+    Collider* mi_collider = pc.c1;
 
-    const mesh_base_t* mb = mi_collider->shape.mesh.mb;
-    v3_t* wsps = mi_collider->shape.mesh.wsps;
+    const MeshBase* mb = mi_collider->shape.mesh.mb;
+    V3* wsps = mi_collider->shape.mesh.wsps;
 
     // TODO: Rneame stuff.
 
@@ -544,16 +544,16 @@ static void narrow_ellipsoid_vs_mi(physics_t* physics, scene_t* scene, potential
     // fully out of the triangle!
     for (int i = 0; i < mb->num_faces * 3; i += 3)
     {
-        v3_t p0 = wsps[mb->position_indices[i]];
-        v3_t p1 = wsps[mb->position_indices[i + 1]];
-        v3_t p2 = wsps[mb->position_indices[i + 2]];
+        V3 p0 = wsps[mb->position_indices[i]];
+        V3 p1 = wsps[mb->position_indices[i + 1]];
+        V3 p2 = wsps[mb->position_indices[i + 2]];
 
         // Convert into ellipsoid space
         v3_mul_eq_v3(&p0, inv_ellipsoid);
         v3_mul_eq_v3(&p1, inv_ellipsoid);
         v3_mul_eq_v3(&p2, inv_ellipsoid);
 
-        plane_t tri_plane = plane_from_points(p0, p1, p2);
+        Plane tri_plane = plane_from_points(p0, p1, p2);
 
         // Backface culling, velocity and normal should face towards each other!
         // dot(A,B) = |A||B|cos(theta), note, we only care about sign.
@@ -564,14 +564,14 @@ static void narrow_ellipsoid_vs_mi(physics_t* physics, scene_t* scene, potential
         float dist = fabsf(D);
 
         uint8_t collided = 0;
-        v3_t collision_point = { 0 };
+        V3 collision_point = { 0 };
 
         float penetration_depth = 0;
 
         // Test unit sphere with triangle plane.
         if (dist <= 1.f)
         {
-            v3_t plane_collision_point = v3_sub_v3(e_start_pos, v3_mul_f(tri_plane.normal, D));
+            V3 plane_collision_point = v3_sub_v3(e_start_pos, v3_mul_f(tri_plane.normal, D));
 
             if (point_in_triangle(plane_collision_point, p0, p1, p2))
             {
@@ -593,17 +593,17 @@ static void narrow_ellipsoid_vs_mi(physics_t* physics, scene_t* scene, potential
 
         if (collided)
         {
-            v3_t actual_plane_collision_point = v3_mul_v3(collision_point, ellipsoid);
+            V3 actual_plane_collision_point = v3_mul_v3(collision_point, ellipsoid);
 
-            v3_t collision_normal = v3_sub_v3(ellipsoid_transform->position, actual_plane_collision_point);
+            V3 collision_normal = v3_sub_v3(ellipsoid_transform->position, actual_plane_collision_point);
             v3_normalise(&collision_normal);
 
-            v3_t n = v3_add_v3(collision_point, collision_normal);
+            V3 n = v3_add_v3(collision_point, collision_normal);
             v3_mul_eq_v3(&n, ellipsoid);
 
             float dist = v3_size(v3_sub_v3(n, e_pos));
 
-            collision_data_t cd = { 0 };
+            CollisionData cd = { 0 };
             cd.collision_normal = collision_normal;
             cd.hit = 1;
             cd.penetration_depth = penetration_depth;
@@ -613,37 +613,37 @@ static void narrow_ellipsoid_vs_mi(physics_t* physics, scene_t* scene, potential
     }
 }
 
-static void narrow_sphere_vs_sphere(physics_t* physics, scene_t* scene, potential_collision_t pc)
+static void narrow_sphere_vs_sphere(Physics* physics, Scene* scene, PotentialCollision pc)
 {
     // NOTE: Currently this means they must already collide as the broad phase is 
     //       sphere vs sphere.
 
     // We are just treating ellipsoids as spheres here.
 
-    v3_t a_pos = pc.t0->position;
-    v3_t b_pos = pc.t1->position;
+    V3 a_pos = pc.t0->position;
+    V3 b_pos = pc.t1->position;
 
-    v3_t a_ellipsoid = pc.c0->shape.ellipsoid;
-    v3_t b_ellipsoid = pc.c1->shape.ellipsoid;
+    V3 a_ellipsoid = pc.c0->shape.ellipsoid;
+    V3 b_ellipsoid = pc.c1->shape.ellipsoid;
 
     // Approximate ellipsoid with sphere.
     float a_radius = max(a_ellipsoid.x, max(a_ellipsoid.y, a_ellipsoid.z));
     float b_radius = max(b_ellipsoid.x, max(b_ellipsoid.y, b_ellipsoid.z));
 
-    v3_t a_vel = pc.pd0 ? pc.pd0->velocity : v3_uniform(0.f);
-    v3_t b_vel = pc.pd1 ? pc.pd1->velocity : v3_uniform(0.f);
+    V3 a_vel = pc.pd0 ? pc.pd0->velocity : v3_uniform(0.f);
+    V3 b_vel = pc.pd1 ? pc.pd1->velocity : v3_uniform(0.f);
 
-    v3_t rel_v = v3_sub_v3(a_vel, b_vel);
-    v3_t rel_p = v3_sub_v3(a_pos, b_pos);
+    V3 rel_v = v3_sub_v3(a_vel, b_vel);
+    V3 rel_p = v3_sub_v3(a_pos, b_pos);
 
-    v3_t n = v3_normalised(rel_p);
+    V3 n = v3_normalised(rel_p);
 
-    v3_t a_deepest = v3_add_v3(a_pos, v3_mul_f(n, -a_radius));
-    v3_t b_deepest = v3_add_v3(b_pos, v3_mul_f(n, b_radius));
+    V3 a_deepest = v3_add_v3(a_pos, v3_mul_f(n, -a_radius));
+    V3 b_deepest = v3_add_v3(b_pos, v3_mul_f(n, b_radius));
 
     float penetration_depth = v3_size(v3_sub_v3(a_deepest, b_deepest));
 
-    collision_data_t cd = { 0 };
+    CollisionData cd = { 0 };
     cd.penetration_depth = penetration_depth;
     cd.collision_normal = n;
     cd.hit = 1;
@@ -652,25 +652,25 @@ static void narrow_sphere_vs_sphere(physics_t* physics, scene_t* scene, potentia
     CHDS_VEC_PUSH_BACK(physics->frame.collisions, cd);
 }
 
-static void narrow_phase(physics_t* physics, scene_t* scene)
+static void narrow_phase(Physics* physics, Scene* scene)
 {
     CHDS_VEC_CLEAR(physics->frame.collisions);
 
     const int num_potential_collisions = (int)CHDS_VEC_SIZE(physics->frame.potential_collisions);
     for (int i = 0; i < num_potential_collisions; ++i)
     {
-        potential_collision_t pc = physics->frame.potential_collisions[i];
+        PotentialCollision pc = physics->frame.potential_collisions[i];
 
         // Sort shapes ascending so we only have to solve A vs B, never B vs A.
         if (pc.c0->shape.type > pc.c1->shape.type)
         {
-            SWAP(collider_t*, pc.c0, pc.c1);
-            SWAP(mesh_instance_t*, pc.mi0, pc.mi1);
-            SWAP(physics_data_t*, pc.pd0, pc.pd1);
-            SWAP(transform_t*, pc.t0, pc.t1);
+            SWAP(Collider*, pc.c0, pc.c1);
+            SWAP(MeshInstance*, pc.mi0, pc.mi1);
+            SWAP(PhysicsData*, pc.pd0, pc.pd1);
+            SWAP(Transform*, pc.t0, pc.t1);
         }
 
-        collision_data_t cd = { 0 };
+        CollisionData cd = { 0 };
 
         // TODO: Could sort by shape value (int) then only have to have to solve A vs B never B vs A.
         switch (pc.c0->shape.type)
@@ -712,7 +712,7 @@ static void narrow_phase(physics_t* physics, scene_t* scene)
     }
 }
 
-static void resolve_collisions(physics_t* physics, scene_t* scene)
+static void resolve_collisions(Physics* physics, Scene* scene)
 {
     // Currently just iterating through the collisions, seems to handle everything well 
     // enough for now, can refactor this to solve collisions together in the future if 
@@ -721,7 +721,7 @@ static void resolve_collisions(physics_t* physics, scene_t* scene)
 
     for (int i = 0; i < num_collisions; ++i)
     {
-        collision_data_t cd = physics->frame.collisions[i];
+        CollisionData cd = physics->frame.collisions[i];
 
         // Combine coefficients by taking averages.
         float e = max(0.f, (cd.pc.c0->restiution_coeff + cd.pc.c1->restiution_coeff) / 2.f);
@@ -731,7 +731,7 @@ static void resolve_collisions(physics_t* physics, scene_t* scene)
     }
 }
 
-uint8_t handle_collisions(physics_t* physics, scene_t* scene)
+uint8_t handle_collisions(Physics* physics, Scene* scene)
 {
     /*
     Outline:
@@ -757,9 +757,9 @@ uint8_t handle_collisions(physics_t* physics, scene_t* scene)
     return (uint8_t)((int)CHDS_VEC_SIZE(physics->frame.collisions) > 0.f);
 }
 
-void collider_init(collider_t* c)
+void collider_init(Collider* c)
 {
-    memset(c, 0, sizeof(collider_t));
+    memset(c, 0, sizeof(Collider));
     c->shape.dirty = 1;
     c->shape.scale_dirty = 1;
 
@@ -773,7 +773,7 @@ void collider_init(collider_t* c)
     c->shape.type = COLLISION_SHAPE_ELLIPSOID;
 }
 
-void collider_destroy(collider_t* c)
+void collider_destroy(Collider* c)
 {
     switch (c->shape.type)
     {

--- a/engine/engine/physics/collision.h
+++ b/engine/engine/physics/collision.h
@@ -5,31 +5,31 @@
 
 #include <chds/vec.h>
 
-typedef struct v3 v3_t;
-typedef struct mesh_base mesh_base_t;
-typedef struct physics physics_t;
-typedef struct scene scene_t;
+typedef struct v3 V3;
+typedef struct mesh_base MeshBase;
+typedef struct physics Physics;
+typedef struct scene Scene;
 
 typedef enum
 {
     COLLISION_SHAPE_ELLIPSOID,
     COLLISION_SHAPE_MESH
-} collision_shape_type_t;
+} CollisionShapeType;
 
 typedef struct
 {
-    const mesh_base_t* mb;
-    CHDS_VEC(v3_t) wsps;
-} collision_mesh_t;
+    const MeshBase* mb;
+    CHDS_VEC(V3) wsps;
+} CollisionMesh;
 
 typedef struct
 {
     // Tagged union for the type narrow phase shape.
-    collision_shape_type_t type;
+    CollisionShapeType type;
     union
     {
-        collision_mesh_t mesh;
-        v3_t ellipsoid;
+        CollisionMesh mesh;
+        V3 ellipsoid;
         float radius;
     };
 
@@ -38,15 +38,15 @@ typedef struct
     uint8_t scale_dirty; // Recalculate bounding sphere radius
 
     // Broad phase shape.
-    bounding_sphere_t bs;
+    BoundingSphere bs;
 
-} collision_shape_t;
+} CollisionShape;
 
 // TODO: Collider stuff could be separated into a new file but not necessary for now.
 // TODO: In the future this could contain some callback etc.
 typedef struct collider
 {
-    collision_shape_t shape;
+    CollisionShape shape;
 
     // Ratio of relative velocity of separation to relative velocity of approach.
     // Determines collisions elasticity (how much energy loss)
@@ -57,11 +57,11 @@ typedef struct collider
     // 0 = no friction, 1 is as much friction as the normal force.
     float friction_coeff;
 
-} collider_t;
+} Collider;
 
-void collider_init(collider_t* c);
-void collider_destroy(collider_t* c);
+void collider_init(Collider* c);
+void collider_destroy(Collider* c);
 
-uint8_t handle_collisions(physics_t* physics, scene_t* scene);
+uint8_t handle_collisions(Physics* physics, Scene* scene);
 
 #endif

--- a/engine/engine/physics/physics.c
+++ b/engine/engine/physics/physics.c
@@ -14,7 +14,7 @@
 
 // TODO: Reorganise functions here.
 
-static void physics_setup_views(physics_t* physics)
+static void physics_setup_views(Physics* physics)
 {
     physics->physics_view = cecs_view_create(physics->ecs,
         CECS_COMPONENT_ID_TO_BITSET(COMPONENT_PHYSICS_DATA) | 
@@ -27,7 +27,7 @@ static void physics_setup_views(physics_t* physics)
         CECS_COMPONENT_ID_TO_BITSET(COMPONENT_COLLIDER),
         0);
 
-    // TODO: Currently these views a mesh_instance_t is this correct?
+    // TODO: Currently these views a MeshInstance is this correct?
 
     // Note, may not actually be moving, just has physicsdata so COULD be moving.
     physics->moving_colliders_view = cecs_view_create(physics->ecs,
@@ -45,9 +45,9 @@ static void physics_setup_views(physics_t* physics)
         CECS_COMPONENT_ID_TO_BITSET(COMPONENT_PHYSICS_DATA));
 }
 
-status_t physics_init(physics_t* physics, cecs* ecs)
+Status physics_init(Physics* physics, cecs* ecs)
 {
-    memset(physics, 0, sizeof(physics_t));
+    memset(physics, 0, sizeof(Physics));
     physics->ecs = ecs;
 
     physics->max_collision_iters = 3;
@@ -59,7 +59,7 @@ status_t physics_init(physics_t* physics, cecs* ecs)
     return STATUS_OK;
 }
 
-static void apply_forces(physics_t* physics, float dt)
+static void apply_forces(Physics* physics, float dt)
 {
     static float elapsed = 0.0f;
 
@@ -69,18 +69,18 @@ static void apply_forces(physics_t* physics, float dt)
 
     // Disable gravity for now.
     // TODO: Define in physics world.
-    static const v3_t gravity = { 0, -9.8f, 0 };
+    static const V3 gravity = { 0, -9.8f, 0 };
     
     cecs_view_iter it = cecs_view_iter_create(physics->ecs, physics->physics_view);
 
     while (cecs_view_iter_next(&it))
     {
-        physics_data_t* physics_datas = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
-        transform_t* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
+        PhysicsData* physics_datas = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
+        Transform* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
 
         for (uint32_t i = 0; i < it.num_entities; ++i)
         {
-            physics_data_t* physics_data = &physics_datas[i];
+            PhysicsData* physics_data = &physics_datas[i];
 
             if (physics_data->mass == 0.f) continue;
 
@@ -89,10 +89,10 @@ static void apply_forces(physics_t* physics, float dt)
             // TODO: Instead of this maybe we could do have a floating flag.
             
 
-            transform_t* transform = &transforms[i];
+            Transform* transform = &transforms[i];
 
             // Sum continuous acceleration.
-            v3_t total_acceleration = { 0 };
+            V3 total_acceleration = { 0 };
 
             if (!physics_data->floating)
             {
@@ -109,8 +109,8 @@ static void apply_forces(physics_t* physics, float dt)
 
             // TODO: essentially i need to figure out what will work best for them game. maybe just remove this for now
             //       honestly. i don't know whether we should use a physically force based drag formula that will take in mass,
-            //       and other parameters (requires more tuning per mi but might feel better), or just a dampening factor on the 
-            //       velocity which would require configuring the damping factor, but that's it.
+            //       and other parameters (reqUIres more tuning per mi but might feel better), or just a dampening factor on the 
+            //       velocity which would reqUIre configuring the damping factor, but that's it.
 
             // Air resistance/drag, simple mass sensitive 
             if (speed > 0.f)
@@ -124,13 +124,13 @@ static void apply_forces(physics_t* physics, float dt)
                 */
 
                 float drag_k = 0.35f; // TODO: Parameter would need to be tuned. e.g. for a 1kg, 0.01m sphere, 0.35 is way too high.
-                //       probs just in physics_data_t? or we could just dampen velocity, but then everytihng would
+                //       probs just in PhysicsData? or we could just dampen velocity, but then everytihng would
                 //       drop at the same speed.
 
                 float drag_mag = drag_k * speed * speed / physics_data->mass;
 
                 // drag_accel = v3_normalised(v) * -drag_mag
-                v3_t drag_accel = v3_mul_f(v3_mul_f(physics_data->velocity, 1.f / speed), -drag_mag);
+                V3 drag_accel = v3_mul_f(v3_mul_f(physics_data->velocity, 1.f / speed), -drag_mag);
 
                 v3_add_eq_v3(&total_acceleration, drag_accel);
 
@@ -148,23 +148,23 @@ static void apply_forces(physics_t* physics, float dt)
             elapsed += dt;
 
             // Clear impulses/instantaneous forces.
-            physics_data->impulses = (v3_t){ 0.f, 0.f, 0.f };
+            physics_data->impulses = (V3){ 0.f, 0.f, 0.f };
         }
     }
 }
 
-static void apply_velocities(physics_t* physics, float dt)
+static void apply_velocities(Physics* physics, float dt)
 {
     cecs_view_iter it = cecs_view_iter_create(physics->ecs, physics->physics_view);
     while (cecs_view_iter_next(&it))
     {
-        physics_data_t* physics_datas = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
-        transform_t* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
+        PhysicsData* physics_datas = cecs_get_column(it, COMPONENT_PHYSICS_DATA);
+        Transform* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
 
         for (uint32_t i = 0; i < it.num_entities; ++i)
         {
-            physics_data_t* physics_data = &physics_datas[i];
-            transform_t* transform = &transforms[i];
+            PhysicsData* physics_data = &physics_datas[i];
+            Transform* transform = &transforms[i];
 
             // Update position with new velocity.
             v3_add_eq_v3(&transform->position, v3_mul_f(physics_data->velocity, dt));
@@ -172,15 +172,15 @@ static void apply_velocities(physics_t* physics, float dt)
     }
 }
 
-void physics_data_init(physics_data_t* data)
+void physics_data_init(PhysicsData* data)
 {
-    memset(data, 0, sizeof(physics_data_t));
+    memset(data, 0, sizeof(PhysicsData));
 
     // Mass of 0 means the object cannot be pushed.
     data->mass = 1.f; 
 }
 
-void physics_tick(physics_t* physics, scene_t* scene, float dt)
+void physics_tick(Physics* physics, Scene* scene, float dt)
 {
     // TODO: TEMP: 
     {
@@ -188,11 +188,11 @@ void physics_tick(physics_t* physics, scene_t* scene, float dt)
         cecs_view_iter it = cecs_view_iter_create(physics->ecs, v);
         while (cecs_view_iter_next(&it))
         {
-            transform_t* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
+            Transform* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
 
             for (uint32_t i = 0; i < it.num_entities; ++i)
             {
-                transform_t* transform = &transforms[i];
+                Transform* transform = &transforms[i];
 
                 transform->previous_position = transform->position;
                 transform->previous_rotation = transform->rotation;

--- a/engine/engine/physics/physics.h
+++ b/engine/engine/physics/physics.h
@@ -23,7 +23,7 @@ typedef struct physics
 
     cecs* ecs;
 
-    physics_frame_t frame;
+    PhysicsFrame frame;
 
     // Views
     cecs_view_id physics_view; // TODO: Rename physicsdata view?
@@ -33,25 +33,25 @@ typedef struct physics
 
     uint8_t max_collision_iters;
 
-} physics_t;
+} Physics;
 
 // TODO: Move to separate file?
 typedef struct physics_data
 {
-    v3_t impulses; // Forces applied instantaneously.
-    v3_t velocity;
+    V3 impulses; // Forces applied instantaneously.
+    V3 velocity;
 
     float mass;
 
     // TODO: TEMP
     uint8_t floating;
-} physics_data_t;
+} PhysicsData;
 
-void physics_data_init(physics_data_t* data);
+void physics_data_init(PhysicsData* data);
 
-status_t physics_init(physics_t* physics, cecs* ecs);
+Status physics_init(Physics* physics, cecs* ecs);
 
-void physics_tick(physics_t* physics, scene_t* scene, float dt);
+void physics_tick(Physics* physics, Scene* scene, float dt);
 
 
 #endif

--- a/engine/engine/physics/physics_frame.h
+++ b/engine/engine/physics/physics_frame.h
@@ -12,10 +12,10 @@
 
 #include <string.h>
 
-typedef struct collider collider_t;
-typedef struct physics_data physics_data_t;
-typedef struct mesh_instance mesh_instance_t;
-typedef struct transform transform_t;
+typedef struct collider Collider;
+typedef struct physics_data PhysicsData;
+typedef struct mesh_instance MeshInstance;
+typedef struct transform Transform;
 
 // TODO: Should this just store the necessary for each entity, i think so? Would make it easier to unpack right and less computations....
 // TODO: An issue with pointers would be if a collision called a 
@@ -27,21 +27,21 @@ typedef struct transform transform_t;
 // TODO: Should this be elsewhere?
 typedef struct
 {
-    const mesh_instance_t* mi0;
-    collider_t* c0;
-    physics_data_t* pd0;
-    transform_t* t0;
+    const MeshInstance* mi0;
+    Collider* c0;
+    PhysicsData* pd0;
+    Transform* t0;
 
-    const mesh_instance_t* mi1;
-    collider_t* c1;
-    physics_data_t* pd1;
-    transform_t* t1;
+    const MeshInstance* mi1;
+    Collider* c1;
+    PhysicsData* pd1;
+    Transform* t1;
     
 
 
 
     /*
-    // collider_t collides with a target.
+    // Collider collides with a target.
     cecs_archetype_id collider_aid;
     int collider_offset;
 
@@ -49,33 +49,33 @@ typedef struct
     int target_offset;
     */
 
-} potential_collision_t;
+} PotentialCollision;
 
 typedef struct
 {
-    v3_t collision_normal;
+    V3 collision_normal;
 
     uint8_t hit;
 
     float penetration_depth;
 
-    potential_collision_t pc; // TODO: TEMP: Just for the entity ptrs?
+    PotentialCollision pc; // TODO: TEMP: Just for the entity ptrs?
 
-} collision_data_t;
+} CollisionData;
 
 typedef struct
 {
-    CHDS_VEC(potential_collision_t) potential_collisions;
-    CHDS_VEC(collision_data_t) collisions;
+    CHDS_VEC(PotentialCollision) potential_collisions;
+    CHDS_VEC(CollisionData) collisions;
 
-} physics_frame_t;
+} PhysicsFrame;
 
-inline void physics_frame_init(physics_frame_t* pf)
+inline void physics_frame_init(PhysicsFrame* pf)
 {
-    memset(pf, 0, sizeof(physics_frame_t));
+    memset(pf, 0, sizeof(PhysicsFrame));
 }
 
-inline void physics_frame_destroy(physics_frame_t* pf)
+inline void physics_frame_destroy(PhysicsFrame* pf)
 {
     chds_vec_destroy(pf->potential_collisions);
     chds_vec_destroy(pf->collisions);

--- a/engine/engine/renderer/camera.c
+++ b/engine/engine/renderer/camera.c
@@ -3,7 +3,7 @@
 #include "maths/matrix4.h"
 #include "maths/vector3.h"
 
-void calculate_view_matrix(const camera_t* camera, m4_t out)
+void calculate_view_matrix(const Camera* camera, M4 out)
 {
 	// The view matrix transforms world space positions to view space. 
 	// Rather than rotating and translating the camera around the 

--- a/engine/engine/renderer/camera.h
+++ b/engine/engine/renderer/camera.h
@@ -10,11 +10,11 @@ typedef struct
 	float yaw;
 	float roll;
 
-	v3_t direction;
-	v3_t position;
+	V3 direction;
+	V3 position;
 
-} camera_t;
+} Camera;
 
-void calculate_view_matrix(const camera_t* camera, m4_t out);
+void calculate_view_matrix(const Camera* camera, M4 out);
 
 #endif 

--- a/engine/engine/renderer/depth_buffer.c
+++ b/engine/engine/renderer/depth_buffer.c
@@ -10,9 +10,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-status_t depth_buffer_init(depth_buffer_t* depth_buffer, int width, int height)
+Status depth_buffer_init(DepthBuffer* depth_buffer, int width, int height)
 {
-	memset(depth_buffer, 0, sizeof(depth_buffer_t));
+	memset(depth_buffer, 0, sizeof(DepthBuffer));
 
 	depth_buffer->width = width;
 	depth_buffer->height = height;
@@ -27,7 +27,7 @@ status_t depth_buffer_init(depth_buffer_t* depth_buffer, int width, int height)
 	return STATUS_OK;
 }
 
-status_t depth_buffer_resize(depth_buffer_t* depth_buffer, int width, int height)
+Status depth_buffer_resize(DepthBuffer* depth_buffer, int width, int height)
 {
 	// Check the size has changed.
 	if (depth_buffer->width == width && depth_buffer->height == height)
@@ -54,7 +54,7 @@ status_t depth_buffer_resize(depth_buffer_t* depth_buffer, int width, int height
 	return STATUS_OK;
 }
 
-void depth_buffer_fill(depth_buffer_t* depth_buffer, float depth)
+void depth_buffer_fill(DepthBuffer* depth_buffer, float depth)
 {
 	// TODO: Look for some sort of blit or fill function 
 	const int length = depth_buffer->width * depth_buffer->height;
@@ -70,7 +70,7 @@ void depth_buffer_fill(depth_buffer_t* depth_buffer, float depth)
 	}
 }
 
-void depth_buffer_draw(const depth_buffer_t* source, canvas_t* target, int x_offset, int y_offset)
+void depth_buffer_draw(const DepthBuffer* source, Canvas* target, int x_offset, int y_offset)
 {
     // TODO: What is this function????
     int* data = target->pixels;
@@ -87,7 +87,7 @@ void depth_buffer_draw(const depth_buffer_t* source, canvas_t* target, int x_off
 	}
 }
 
-void depth_buffer_destroy(depth_buffer_t* depth_buffer)
+void depth_buffer_destroy(DepthBuffer* depth_buffer)
 {
 	free(depth_buffer->data);
 	depth_buffer->data = 0;

--- a/engine/engine/renderer/depth_buffer.h
+++ b/engine/engine/renderer/depth_buffer.h
@@ -12,17 +12,17 @@ typedef struct
 	int width, height;
 	float* data;
 
-} depth_buffer_t;
+} DepthBuffer;
 
-status_t depth_buffer_init(depth_buffer_t* depth_buffer, int width, int height);
+Status depth_buffer_init(DepthBuffer* depth_buffer, int width, int height);
 
-status_t depth_buffer_resize(depth_buffer_t* depth_buffer, int width, int height);
+Status depth_buffer_resize(DepthBuffer* depth_buffer, int width, int height);
 
-void depth_buffer_fill(depth_buffer_t* depth_buffer, float depth);
+void depth_buffer_fill(DepthBuffer* depth_buffer, float depth);
 
-void depth_buffer_draw(const depth_buffer_t* source, canvas_t* target, int x_offset, int y_offset);
+void depth_buffer_draw(const DepthBuffer* source, Canvas* target, int x_offset, int y_offset);
 
-void depth_buffer_destroy(depth_buffer_t* depth_buffer);
+void depth_buffer_destroy(DepthBuffer* depth_buffer);
 
 
 #endif

--- a/engine/engine/renderer/draw_2d.c
+++ b/engine/engine/renderer/draw_2d.c
@@ -2,7 +2,7 @@
 
 #include <math.h>
 
-void draw_line(canvas_t* canvas, int x0, int y0, int x1, int y1, int colour)
+void draw_line(Canvas* canvas, int x0, int y0, int x1, int y1, int colour)
 {
 	int dx = abs(x1 - x0);
 	int sx = x0 < x1 ? 1 : -1;
@@ -37,7 +37,7 @@ void draw_line(canvas_t* canvas, int x0, int y0, int x1, int y1, int colour)
 	}
 }
 
-void draw_circle(canvas_t* canvas, int cx, int cy, int r, int colour)
+void draw_circle(Canvas* canvas, int cx, int cy, int r, int colour)
 {
 
 	// (x-a)^2 + (y-b)^2
@@ -72,7 +72,7 @@ void draw_circle(canvas_t* canvas, int cx, int cy, int r, int colour)
 	}
 }
 
-void draw_rect(canvas_t* canvas, int x0, int y0, int x1, int y1, int colour)
+void draw_rect(Canvas* canvas, int x0, int y0, int x1, int y1, int colour)
 {
     int* pixels = canvas->pixels;
 

--- a/engine/engine/renderer/draw_2d.h
+++ b/engine/engine/renderer/draw_2d.h
@@ -4,8 +4,8 @@
 #include "core/canvas.h"
 
 // TODO: Documentation comments
-void draw_line(canvas_t* canvas, int x0, int y0, int x1, int y1, int colour);
-void draw_circle(canvas_t* canvas, int cx, int cy, int r, int colour);
-void draw_rect(canvas_t* canvas, int x0, int y0, int x1, int y1, int colour);
+void draw_line(Canvas* canvas, int x0, int y0, int x1, int y1, int colour);
+void draw_circle(Canvas* canvas, int cx, int cy, int r, int colour);
+void draw_rect(Canvas* canvas, int x0, int y0, int x1, int y1, int colour);
 
 #endif

--- a/engine/engine/renderer/frame_data.c
+++ b/engine/engine/renderer/frame_data.c
@@ -12,12 +12,12 @@
 
 #include <Windows.h> // max - TODO: Somewhere else?
 
-status_t frame_data_init(
+Status frame_data_init(
     cecs* ecs, 
     cecs_view_id render_view,
     cecs_view_id lighting_view,
-    frame_data_t* frame_data, 
-    scene_t* scene)
+    FrameData* frame_data, 
+    Scene* scene)
 {
     // TODO: A big issue with this view is that it will simply fail if 
     //       we don't have enough memory, honestly no clue how we could
@@ -34,18 +34,18 @@ status_t frame_data_init(
     int total_faces = 0;
     int most_faces = 0;
 
-    const mesh_base_t* mbs = scene->mesh_bases.bases;
+    const MeshBase* mbs = scene->mesh_bases.bases;
 
     cecs_view_iter it = cecs_view_iter_create(ecs, render_view);
     while (cecs_view_iter_next(&it))
     {
-        mesh_instance_t* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
+        MeshInstance* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
 
         for (int i = 0; i < it.num_entities; ++i)
         {
-            mesh_instance_t* mi = &mis[i];
+            MeshInstance* mi = &mis[i];
 
-            const mesh_base_t* mb = &scene->mesh_bases.bases[mi->mb_id];
+            const MeshBase* mb = &scene->mesh_bases.bases[mi->mb_id];
             total_positions += mb->num_positions;
             total_normals += mb->num_normals;
             total_faces += mb->num_faces;
@@ -56,7 +56,7 @@ status_t frame_data_init(
         }
     }
 
-	// transform_t Stage
+	// Transform Stage
     CHDS_VEC_RESERVE(frame_data->view_space_positions, total_positions * STRIDE_POSITION);
 	
 	// TODO: Fails in release?? heap corruption, so potentially from before?
@@ -113,6 +113,6 @@ status_t frame_data_init(
 	return STATUS_OK;
 }
 
-void frame_data_destroy(frame_data_t* frame_data)
+void frame_data_destroy(FrameData* frame_data)
 {
 }

--- a/engine/engine/renderer/frame_data.h
+++ b/engine/engine/renderer/frame_data.h
@@ -20,14 +20,14 @@ typedef struct
 {
     float physics_alpha; // Time through the physics step, used for smooth interpolation.
 
-	// transform_t Stage
-	CHDS_VEC(v3_t) view_space_positions;
-    CHDS_VEC(v3_t) view_space_normals;
+	// Transform Stage
+	CHDS_VEC(V3) view_space_positions;
+    CHDS_VEC(V3) view_space_normals;
 
-    CHDS_VEC(v3_t) point_lights_view_space_positions;
+    CHDS_VEC(V3) point_lights_view_space_positions;
 
 	// Broad Phase Frustum Culling
-    CHDS_VEC(mesh_instance_t) visible_mis;
+    CHDS_VEC(MeshInstance) visible_mis;
 	int num_visible_mis;
 	CHDS_VEC(uint8_t) intersected_planes;
 
@@ -49,7 +49,7 @@ typedef struct
 
     // TODO: Refactoring this so it's not just float arrays.
 	
-    CHDS_VEC(v3_t) vertex_lighting;
+    CHDS_VEC(V3) vertex_lighting;
 
 	// Clipping
     CHDS_VEC(float) faces_to_clip;  // Input to clip.
@@ -60,17 +60,17 @@ typedef struct
     CHDS_VEC(float) temp_clipped_faces0; 
     CHDS_VEC(float) temp_clipped_faces1;
 
-} frame_data_t;
+} FrameData;
 
-status_t frame_data_init(
+Status frame_data_init(
     cecs* ecs, 
     cecs_view_id render_view, 
     cecs_view_id lighting_view, 
-    frame_data_t* frame_data, 
-    scene_t* scene);
+    FrameData* frame_data, 
+    Scene* scene);
 
 
-void frame_data_destroy(frame_data_t* frame_data);
+void frame_data_destroy(FrameData* frame_data);
 
 
 #endif

--- a/engine/engine/renderer/frustum_culling.c
+++ b/engine/engine/renderer/frustum_culling.c
@@ -4,10 +4,10 @@
 
 #include <string.h>
 
-void view_frustum_init(view_frustum_t* view_frustum, float near_dist, float far_dist, float fov, float aspect_ratio)
+void view_frustum_init(ViewFrustum* view_frustum, float near_dist, float far_dist, float fov, float aspect_ratio)
 {
 	// Reset the struct.
-	memset(view_frustum, 0, sizeof(view_frustum_t));
+	memset(view_frustum, 0, sizeof(ViewFrustum));
 
 	// Calculate the dimensions of the near and far planes.
 	float double_tanf_half_fov = 2.f * tanf(radians(fov) / 2.f);
@@ -22,39 +22,39 @@ void view_frustum_init(view_frustum_t* view_frustum, float near_dist, float far_
 	// TODO: Should these be defined globally somewhere? or at least in a function? like v3_world_up?
 	// TODO: Also these are really world up as well. Not specific to view space. 
 	// TODO: Should be defined in some engine_globals.h maybe.
-	v3_t view_forward = { 0, 0, -1.f };
-	v3_t view_up = { 0, 1.f, 0 };
-	v3_t view_right = { 1.f, 0, 0 };
+	V3 view_forward = { 0, 0, -1.f };
+	V3 view_up = { 0, 1.f, 0 };
+	V3 view_right = { 1.f, 0, 0 };
 
 	// Define offsets for the near and far planes.
-	v3_t near_centre = v3_mul_f(view_forward, near_dist);
-	v3_t near_top_offset = v3_mul_f(view_up, near_height * 0.5f);
-	v3_t near_right_offset = v3_mul_f(view_right, near_width * 0.5f);
+	V3 near_centre = v3_mul_f(view_forward, near_dist);
+	V3 near_top_offset = v3_mul_f(view_up, near_height * 0.5f);
+	V3 near_right_offset = v3_mul_f(view_right, near_width * 0.5f);
 
-	v3_t far_centre = v3_mul_f(view_forward, far_dist);
-	v3_t far_top_offset = v3_mul_f(view_up, far_height * 0.5f);
-	v3_t far_right_offset = v3_mul_f(view_right, far_width * 0.5f);
+	V3 far_centre = v3_mul_f(view_forward, far_dist);
+	V3 far_top_offset = v3_mul_f(view_up, far_height * 0.5f);
+	V3 far_right_offset = v3_mul_f(view_right, far_width * 0.5f);
 
 	// To calculate each plane normal, we can define 3 points on each plane
 	// and use the cross product of the edges. So define the four corners
 	// of each plane.
-	v3_t near_top_left = v3_sub_v3(v3_add_v3(near_centre, near_top_offset), near_right_offset);
-	v3_t near_top_right = v3_add_v3(v3_add_v3(near_centre, near_top_offset), near_right_offset);
-	v3_t near_bottom_left = v3_sub_v3(v3_sub_v3(near_centre, near_top_offset), near_right_offset);
-	v3_t near_bottom_right = v3_add_v3(v3_sub_v3(near_centre, near_top_offset), near_right_offset);
+	V3 near_top_left = v3_sub_v3(v3_add_v3(near_centre, near_top_offset), near_right_offset);
+	V3 near_top_right = v3_add_v3(v3_add_v3(near_centre, near_top_offset), near_right_offset);
+	V3 near_bottom_left = v3_sub_v3(v3_sub_v3(near_centre, near_top_offset), near_right_offset);
+	V3 near_bottom_right = v3_add_v3(v3_sub_v3(near_centre, near_top_offset), near_right_offset);
 
-	v3_t far_top_left = v3_sub_v3(v3_add_v3(far_centre, far_top_offset), far_right_offset);
-	v3_t far_top_right = v3_add_v3(v3_add_v3(far_centre, far_top_offset), far_right_offset);
-	//v3_t far_bottom_left = v3_sub_v3(v3_sub_v3(far_centre, far_top_offset), far_right_offset);
-	//v3_t far_bottom_right = v3_add_v3(v3_sub_v3(far_centre, far_top_offset), far_right_offset);
+	V3 far_top_left = v3_sub_v3(v3_add_v3(far_centre, far_top_offset), far_right_offset);
+	V3 far_top_right = v3_add_v3(v3_add_v3(far_centre, far_top_offset), far_right_offset);
+	//V3 far_bottom_left = v3_sub_v3(v3_sub_v3(far_centre, far_top_offset), far_right_offset);
+	//V3 far_bottom_right = v3_add_v3(v3_sub_v3(far_centre, far_top_offset), far_right_offset);
 
 	// Near and far are trivial to define.
-	plane_t near = {
+	Plane near = {
 		.point = near_centre,
 		.normal = { 0, 0, -1.f}
 	};
 
-	plane_t far = {
+	Plane far = {
 		.point = far_centre,
 		.normal = { 0, 0, 1.f}
 	};
@@ -62,25 +62,25 @@ void view_frustum_init(view_frustum_t* view_frustum, float near_dist, float far_
 	// Define the left/right planes, opposite x direction.
 
     // TODO: Functoin for calculating plane from 3 points.
-	plane_t right = { 
+	Plane right = { 
 		.point = near_top_right, 
 		.normal = v3_normalised(cross(v3_sub_v3(near_top_right, near_bottom_right), v3_sub_v3(far_top_right, near_bottom_right)))
 	};
 	
 	// Define the left plane.
-	plane_t left = { 
+	Plane left = { 
 		.point = near_top_left,
 		.normal = right.normal
 	};
 	left.normal.x *= -1;
 
 	// Define the top/bottom planes, opposite y direction.
-	plane_t top = {
+	Plane top = {
 		.point = near_top_left,
 		.normal = v3_normalised(cross(v3_sub_v3(far_top_right, far_top_left), v3_sub_v3(near_top_left, far_top_left)))
 	};
 
-	plane_t bottom = {
+	Plane bottom = {
 		.point = near_bottom_left,
 		.normal = top.normal
 	};

--- a/engine/engine/renderer/frustum_culling.h
+++ b/engine/engine/renderer/frustum_culling.h
@@ -11,12 +11,12 @@
 
 typedef struct
 {
-	plane_t planes[MAX_FRUSTUM_PLANES];
+	Plane planes[MAX_FRUSTUM_PLANES];
 	int planes_count;
 
-} view_frustum_t;
+} ViewFrustum;
 
-void view_frustum_init(view_frustum_t* view_frustum, float near_dist, float far_dist, float fov, float aspect_ratio);
+void view_frustum_init(ViewFrustum* view_frustum, float near_dist, float far_dist, float fov, float aspect_ratio);
 
 
 #endif

--- a/engine/engine/renderer/render.c
+++ b/engine/engine/renderer/render.c
@@ -30,25 +30,25 @@
 // TODO: Something important would be to make the buffer accesses easier.
 
 void debug_draw_point_lights(
-    canvas_t* canvas, 
+    Canvas* canvas, 
     const cecs* ecs,
     const cecs_view_id lighting_view,
-    const frame_data_t* frame_data, 
-    const render_settings_t* settings
+    const FrameData* frame_data, 
+    const RenderSettings* settings
     )
 {
-    const v3_t* vsps = frame_data->point_lights_view_space_positions;
+    const V3* vsps = frame_data->point_lights_view_space_positions;
     int vsps_offset = 0;
 
     // Debug draw point light icons as rects.
     cecs_view_iter it = cecs_view_iter_create(ecs, lighting_view);
     while (cecs_view_iter_next(&it))
     {
-        point_light_t* pls = cecs_get_column(it, COMPONENT_POINT_LIGHT);
+        PointLight* pls = cecs_get_column(it, COMPONENT_POINT_LIGHT);
 
         for (int i = 0; i < it.num_entities; ++i)
         {
-            v4_t p = v3_to_v4(vsps[vsps_offset], 1.f);
+            V4 p = v3_to_v4(vsps[vsps_offset], 1.f);
             ++vsps_offset;
 
             // Only draw if depth is visibile in clip space.
@@ -57,10 +57,10 @@ void debug_draw_point_lights(
                 continue;
             }
 
-            v4_t projected;
+            V4 projected;
             project(canvas, settings->projection_matrix, p, &projected);
 
-            v3_t colour_v3 = pls[i].colour;
+            V3 colour_v3 = pls[i].colour;
 
             int colour = float_rgb_to_int(colour_v3.x, colour_v3.y, colour_v3.z);
 
@@ -78,10 +78,10 @@ void debug_draw_point_lights(
     }
 }
 
-void debug_draw_view_space_point(canvas_t* canvas, const render_settings_t* settings, v3_t point, int colour)
+void debug_draw_view_space_point(Canvas* canvas, const RenderSettings* settings, V3 point, int colour)
 {
     // Convert from world space to screen space.
-    v4_t vsp = v3_to_v4(point, 1.f);
+    V4 vsp = v3_to_v4(point, 1.f);
 
     // Don't draw points behind the camera.
     if (vsp.z > -settings->near_plane)
@@ -89,7 +89,7 @@ void debug_draw_view_space_point(canvas_t* canvas, const render_settings_t* sett
         return;
     }
 
-    v4_t ssp;
+    V4 ssp;
     project(canvas, settings->projection_matrix, vsp, &ssp);
 
     int n = 2;
@@ -101,11 +101,11 @@ void debug_draw_view_space_point(canvas_t* canvas, const render_settings_t* sett
     draw_rect(canvas, x0, y0, x1, y1, colour);
 }
 
-void debug_draw_normals(canvas_t* canvas, const frame_data_t* frame_data, const render_settings_t* settings, const scene_t* scene)
+void debug_draw_normals(Canvas* canvas, const FrameData* frame_data, const RenderSettings* settings, const Scene* scene)
 {
     /*
-    const mesh_instance_t* mis = scene->mesh_instances.instances;
-    const mesh_base_t* mbs = scene->mesh_bases.bases;
+    const MeshInstance* mis = scene->mesh_instances.instances;
+    const MeshBase* mbs = scene->mesh_bases.bases;
 
     // TODO: Will need to calculate the actual stride of a vertex with the number of light space positions
     //		 too. Maybe to simplify this for all of my functions, should calculate this and keep it in the renderer.
@@ -121,8 +121,8 @@ void debug_draw_normals(canvas_t* canvas, const frame_data_t* frame_data, const 
 
     for (int i = 0; i < num_visible_mis; ++i)
     {
-        const mesh_instance_t* mi = &mis[visible_mi_indices[i]];
-        const mesh_base_t* mb = &mbs[mi->mb_id];
+        const MeshInstance* mi = &mis[visible_mi_indices[i]];
+        const MeshBase* mb = &mbs[mi->mb_id];
 
         const int* position_indices = mb->position_indices;
         const int* normal_indices = mb->normal_indices;
@@ -138,18 +138,18 @@ void debug_draw_normals(canvas_t* canvas, const frame_data_t* frame_data, const 
                 const int p_index = vsp_offset + position_indices[face_index + k] * STRIDE_POSITION;
                 const int n_index = vsn_offset + normal_indices[face_index + k] * STRIDE_NORMAL;
 
-                // TODO: Would just storing as a v3_t be better?
-                const v3_t p = v3_read(vsps + p_index);
-                const v3_t n = v3_read(vsns + n_index);
+                // TODO: Would just storing as a V3 be better?
+                const V3 p = v3_read(vsps + p_index);
+                const V3 n = v3_read(vsns + n_index);
 
                 const float length = 2.5f;
 
-                v3_t end = v3_add_v3(p, v3_mul_f(n, length));
+                V3 end = v3_add_v3(p, v3_mul_f(n, length));
 
-                v4_t start_v4 = v3_to_v4(p, 1.f);
-                v4_t end_v4 = v3_to_v4(end, 1.f);
+                V4 start_v4 = v3_to_v4(p, 1.f);
+                V4 end_v4 = v3_to_v4(end, 1.f);
 
-                v4_t ss_start, ss_end;
+                V4 ss_start, ss_end;
                 project(canvas, settings->projection_matrix, start_v4, &ss_start);
                 project(canvas, settings->projection_matrix, end_v4, &ss_end);
 
@@ -162,7 +162,7 @@ void debug_draw_normals(canvas_t* canvas, const frame_data_t* frame_data, const 
 }
 
 /*
-void debug_draw_bounding_spheres(canvas_t* canvas, const render_settings_t* settings, const Models* models, const m4_t view_matrix)
+void debug_draw_bounding_spheres(Canvas* canvas, const RenderSettings* settings, const Models* models, const M4 view_matrix)
 {
 	// TODO: This doesn't really work.
 
@@ -174,7 +174,7 @@ void debug_draw_bounding_spheres(canvas_t* canvas, const render_settings_t* sett
 	{
 		int sphere_index = i * STRIDE_SPHERE;
 
-		v3_t view_centre_v3 = {
+		V3 view_centre_v3 = {
 			models->mis_bounding_spheres[sphere_index],
 			models->mis_bounding_spheres[sphere_index + 1],
 			models->mis_bounding_spheres[sphere_index + 2]
@@ -182,9 +182,9 @@ void debug_draw_bounding_spheres(canvas_t* canvas, const render_settings_t* sett
 
 		debug_draw_view_space_point(canvas, settings, view_centre_v3, COLOUR_LIME);
 
-		v4_t view_centre = v3_to_v4(view_centre_v3, 1.f);
+		V4 view_centre = v3_to_v4(view_centre_v3, 1.f);
 
-		v4_t view_centre = m4_mul_v4(view_matrix, world_centre_v4);
+		V4 view_centre = m4_mul_v4(view_matrix, world_centre_v4);
 
 		if (view_centre.z > -settings->near_plane)
 		{
@@ -193,19 +193,19 @@ void debug_draw_bounding_spheres(canvas_t* canvas, const render_settings_t* sett
 
 		float radius = models->mis_bounding_spheres[3];
 
-		v4_t world_bottom = world_centre_v4;
+		V4 world_bottom = world_centre_v4;
 		world_bottom.y -= radius;
 
-		v4_t view_bottom = m4_mul_v4(view_matrix, world_bottom);
+		V4 view_bottom = m4_mul_v4(view_matrix, world_bottom);
 
-		v4_t world_top = world_centre_v4;
+		V4 world_top = world_centre_v4;
 		world_top.y += radius;
 
-		v4_t view_top = m4_mul_v4(view_matrix, world_top);
+		V4 view_top = m4_mul_v4(view_matrix, world_top);
 
-		v4_t pc = project(canvas, settings->projection_matrix, view_centre);
-		v4_t pt = project(canvas, settings->projection_matrix, view_top);
-		v4_t pb = project(canvas, settings->projection_matrix, view_bottom);
+		V4 pc = project(canvas, settings->projection_matrix, view_centre);
+		V4 pt = project(canvas, settings->projection_matrix, view_top);
+		V4 pb = project(canvas, settings->projection_matrix, view_bottom);
 		
 		float pr = fabsf(pb.y - pt.y) / 2.f;
 		
@@ -213,12 +213,12 @@ void debug_draw_bounding_spheres(canvas_t* canvas, const render_settings_t* sett
 	}
 }*/
 
-void debug_draw_world_space_point(canvas_t* canvas, const render_settings_t* settings, v3_t point, const m4_t view_matrix, int colour)
+void debug_draw_world_space_point(Canvas* canvas, const RenderSettings* settings, V3 point, const M4 view_matrix, int colour)
 {
 	// Convert from world space to screen space.
-	v4_t wsp = v3_to_v4(point, 1.f);
+	V4 wsp = v3_to_v4(point, 1.f);
 
-	v4_t vsp;
+	V4 vsp;
 	m4_mul_v4(view_matrix, wsp, &vsp);
 	
 	// Don't draw points behind the camera.
@@ -227,7 +227,7 @@ void debug_draw_world_space_point(canvas_t* canvas, const render_settings_t* set
 		return;
 	}
 
-	v4_t ssp;
+	V4 ssp;
 	project(canvas, settings->projection_matrix, vsp, &ssp);
 
 	// TODO: Could be a draw 2d rect function.
@@ -240,12 +240,12 @@ void debug_draw_world_space_point(canvas_t* canvas, const render_settings_t* set
 	draw_rect(canvas, x0, y0, x1, y1, colour);
 }
 
-void debug_draw_world_space_line(canvas_t* canvas, const render_settings_t* settings, const m4_t view_matrix, v3_t v0, v3_t v1, v3_t colour)
+void debug_draw_world_space_line(Canvas* canvas, const RenderSettings* settings, const M4 view_matrix, V3 v0, V3 v1, V3 colour)
 {
-	v4_t ws_v0 = v3_to_v4(v0, 1.f);
-	v4_t ws_v1 = v3_to_v4(v1, 1.f);
+	V4 ws_v0 = v3_to_v4(v0, 1.f);
+	V4 ws_v1 = v3_to_v4(v1, 1.f);
 
-	v4_t vs_v0, vs_v1;
+	V4 vs_v0, vs_v1;
 	m4_mul_v4(view_matrix, ws_v0, &vs_v0);
 	m4_mul_v4(view_matrix, ws_v1, &vs_v1);
 
@@ -280,7 +280,7 @@ void debug_draw_world_space_line(canvas_t* canvas, const render_settings_t* sett
 		vs_v1.z = -settings->near_plane;
 	}
 
-	v4_t ss_v0, ss_v1; 
+	V4 ss_v0, ss_v1; 
 	project(canvas, settings->projection_matrix, vs_v0, &ss_v0);
 	project(canvas, settings->projection_matrix, vs_v1, &ss_v1);
 
@@ -289,12 +289,12 @@ void debug_draw_world_space_line(canvas_t* canvas, const render_settings_t* sett
 	draw_line(canvas, (int)ss_v0.x, (int)ss_v0.y, (int)ss_v1.x, (int)ss_v1.y, colour_int);
 }
 
-void draw_scanline(render_target_t* rt,
+void draw_scanline(RenderTarget* rt,
 	int x0, int x1,
 	int y,
 	float z0, float z1,
 	float w0, float w1,
-	v3_t start_colour, v3_t end_colour)
+	V3 start_colour, V3 end_colour)
 {
 	// TODO: Globals could be used for the render target pixels and depth buffer to make faster? Maybe? Would need to profile idk.
 
@@ -326,10 +326,10 @@ void draw_scanline(render_target_t* rt,
 	float z_step = (z1 - z0) * inv_dx;
 
 	
-	v3_t colour_step = v3_mul_f(v3_sub_v3(end_colour, start_colour), inv_dx);
+	V3 colour_step = v3_mul_f(v3_sub_v3(end_colour, start_colour), inv_dx);
 
 	
-	v3_t colour = start_colour;
+	V3 colour = start_colour;
 
 	for (unsigned int i = 0; i < dx; ++i)
 	{
@@ -358,7 +358,7 @@ void draw_scanline(render_target_t* rt,
 	}
 }
 
-void draw_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2)
+void draw_flat_bottom_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2)
 {
 	// Sort the flat vertices left to right.
 	if (vc1[0] > vc2[0])
@@ -366,13 +366,13 @@ void draw_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, floa
         SWAP(float*, vc1, vc2);
 	}
 
-	const v4_t v0 = v4_read(vc0);
-	const v4_t v1 = v4_read(vc1);
-	const v4_t v2 = v4_read(vc2);
+	const V4 v0 = v4_read(vc0);
+	const V4 v1 = v4_read(vc1);
+	const V4 v2 = v4_read(vc2);
 
-	const v3_t c0 = v3_read(vc0 + 4);
-	const v3_t c1 = v3_read(vc1 + 4);
-	const v3_t c2 = v3_read(vc2 + 4);
+	const V3 c0 = v3_read(vc0 + 4);
+	const V3 c1 = v3_read(vc1 + 4);
+	const V3 c2 = v3_read(vc2 + 4);
 
 	float inv_dy = 1 / (v2.y - v0.y);
 
@@ -388,8 +388,8 @@ void draw_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, floa
 	int start_y = (int)(ceil(v0.y - 0.5f));
 	int end_y = (int)(ceil(v2.y - 0.5f));
 
-	v3_t dcdy0 = v3_mul_f(v3_sub_v3(c1, c0), inv_dy);
-	v3_t dcdy1 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
+	V3 dcdy0 = v3_mul_f(v3_sub_v3(c1, c0), inv_dy);
+	V3 dcdy1 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
 
 	for (int y = start_y; y < end_y; ++y) {
 		// Must lerp for the vertex attributes otherwise the accuracy is poor.
@@ -409,14 +409,14 @@ void draw_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, floa
 		int start_x = (int)((x0 - 0.5f));
 		int end_x = (int)((x1 - 0.5f));
 
-		v3_t start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
-		v3_t end_colour = v3_add_v3(c0, v3_mul_f(dcdy1, a));
+		V3 start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
+		V3 end_colour = v3_add_v3(c0, v3_mul_f(dcdy1, a));
 		
 		draw_scanline(rt, start_x, end_x, y, z0, z1, start_w, end_w, start_colour, end_colour);
 	}
 }
 
-void draw_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2)
+void draw_flat_top_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2)
 {
 	// Sort the flat vertices left to right.
 	if (vc0[0] > vc1[0])
@@ -424,13 +424,13 @@ void draw_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* 
         SWAP(float*, vc0, vc1);
 	}
 
-	v4_t v0 = v4_read(vc0);
-	v4_t v1 = v4_read(vc1);
-	v4_t v2 = v4_read(vc2);
+	V4 v0 = v4_read(vc0);
+	V4 v1 = v4_read(vc1);
+	V4 v2 = v4_read(vc2);
 
-	const v3_t c0 = v3_read(vc0 + 4);
-	const v3_t c1 = v3_read(vc1 + 4);
-	const v3_t c2 = v3_read(vc2 + 4);
+	const V3 c0 = v3_read(vc0 + 4);
+	const V3 c1 = v3_read(vc1 + 4);
+	const V3 c2 = v3_read(vc2 + 4);
 
 	float inv_dy = 1 / (v2.y - v0.y);
 
@@ -446,8 +446,8 @@ void draw_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* 
 	int start_y = (int)(ceil(v0.y - 0.5f));
 	int end_y = (int)(ceil(v2.y - 0.5f));
 
-	v3_t dcdy0 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
-	v3_t dcdy1 = v3_mul_f(v3_sub_v3(c2, c1), inv_dy);
+	V3 dcdy0 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
+	V3 dcdy1 = v3_mul_f(v3_sub_v3(c2, c1), inv_dy);
 	
 	for (int y = start_y; y < end_y; ++y) {
 		// Must lerp for the vertex attributes to get them accurately.
@@ -470,14 +470,14 @@ void draw_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* 
 		int start_x = (int)((x0 - 0.5f));
 		int end_x = (int)((x1 - 0.5f));
 
-		v3_t start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
-		v3_t end_colour = v3_add_v3(c1, v3_mul_f(dcdy1, a));
+		V3 start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
+		V3 end_colour = v3_add_v3(c1, v3_mul_f(dcdy1, a));
 
 		draw_scanline(rt, start_x, end_x, y, z0, z1, start_w, end_w, start_colour, end_colour);
 	}
 }
 
-void draw_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2)
+void draw_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2)
 {
 	// vc = vertex components
 
@@ -539,7 +539,7 @@ void draw_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2)
 	draw_flat_bottom_triangle(rt, vc0, vc1, vc3);
 }
 
-void draw_textured_scanline(render_target_t* rt, int x0, int x1, int y, float z0, float z1, float w0, float w1, const v3_t c0, const v3_t c1, const v2_t uv0, const v2_t uv1, const texture_t* texture)
+void draw_textured_scanline(RenderTarget* rt, int x0, int x1, int y, float z0, float z1, float w0, float w1, const V3 c0, const V3 c1, const V2 uv0, const V2 uv1, const Texture* texture)
 {
 	// TODO: Refactor function args.
 	if (x0 == x1) return;
@@ -556,15 +556,15 @@ void draw_textured_scanline(render_target_t* rt, int x0, int x1, int y, float z0
 	int start_x = x0 + row_offset;
 	int end_x = x1 + row_offset;
 
-	v3_t c_step = v3_mul_f(v3_sub_v3(c1, c0), inv_dx);
-	v3_t c = c0;
+	V3 c_step = v3_mul_f(v3_sub_v3(c1, c0), inv_dx);
+	V3 c = c0;
 
 	v3_mul_eq_f(&c_step, 255);
 	v3_mul_eq_f(&c, 255);
 
-	v2_t uv = uv0;
+	V2 uv = uv0;
 
-	v2_t uv_step = 
+	V2 uv_step = 
 	{
 		(uv1.x - uv0.x) * inv_dx,
 		(uv1.y - uv0.y) * inv_dx
@@ -598,7 +598,7 @@ void draw_textured_scanline(render_target_t* rt, int x0, int x1, int y, float z0
 			int cols = (int)((uv.x * w));
 			int rows = (int)((uv.y * w));
 
-			int n = (rows * texture_width + cols) * 3; // texture_t is split into float r,g,b components.
+			int n = (rows * texture_width + cols) * 3; // Texture is split into float r,g,b components.
 			
 			float r = texture_data[n] * c.x * w;
 			float g = texture_data[n + 1] * c.y * w;
@@ -633,7 +633,7 @@ void draw_textured_scanline(render_target_t* rt, int x0, int x1, int y, float z0
 	}
 }
 
-void draw_textured_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2, const texture_t* texture)
+void draw_textured_flat_bottom_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2, const Texture* texture)
 {
     // Sort the flat vertices left to right.
     if (vc1[0] > vc2[0])
@@ -641,17 +641,17 @@ void draw_textured_flat_bottom_triangle(render_target_t* rt, float* vc0, float* 
         SWAP(float*, vc1, vc2);
     }
 
-    const v4_t v0 = v4_read(vc0);
-    const v4_t v1 = v4_read(vc1);
-    const v4_t v2 = v4_read(vc2);
+    const V4 v0 = v4_read(vc0);
+    const V4 v1 = v4_read(vc1);
+    const V4 v2 = v4_read(vc2);
 
-    const v3_t c0 = v3_read(vc0 + 4);
-    const v3_t c1 = v3_read(vc1 + 4);
-    const v3_t c2 = v3_read(vc2 + 4);
+    const V3 c0 = v3_read(vc0 + 4);
+    const V3 c1 = v3_read(vc1 + 4);
+    const V3 c2 = v3_read(vc2 + 4);
 
-    const v2_t uv0 = v2_read(vc0 + 7);
-    const v2_t uv1 = v2_read(vc1 + 7);
-    const v2_t uv2 = v2_read(vc2 + 7);
+    const V2 uv0 = v2_read(vc0 + 7);
+    const V2 uv1 = v2_read(vc1 + 7);
+    const V2 uv2 = v2_read(vc2 + 7);
 
     float inv_dy = 1 / (v2.y - v0.y);
 
@@ -667,11 +667,11 @@ void draw_textured_flat_bottom_triangle(render_target_t* rt, float* vc0, float* 
     int start_y = (int)(ceil(v0.y - 0.5f));
     int end_y = (int)(ceil(v2.y - 0.5f));
 
-    v3_t dcdy0 = v3_mul_f(v3_sub_v3(c1, c0), inv_dy);
-    v3_t dcdy1 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
+    V3 dcdy0 = v3_mul_f(v3_sub_v3(c1, c0), inv_dy);
+    V3 dcdy1 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
 
-    v2_t duvdy0 = v2_mul_f(v2_sub_v2(uv1, uv0), inv_dy);
-    v2_t duvdy1 = v2_mul_f(v2_sub_v2(uv2, uv0), inv_dy);
+    V2 duvdy0 = v2_mul_f(v2_sub_v2(uv1, uv0), inv_dy);
+    V2 duvdy1 = v2_mul_f(v2_sub_v2(uv2, uv0), inv_dy);
 
     for (int y = start_y; y < end_y; ++y) {
         // Must lerp for the vertex attributes otherwise the accuracy is poor.
@@ -691,17 +691,17 @@ void draw_textured_flat_bottom_triangle(render_target_t* rt, float* vc0, float* 
         int start_x = (int)((x0 - 0.5f));
         int end_x = (int)((x1 - 0.5f));
 
-        v3_t start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
-        v3_t end_colour = v3_add_v3(c0, v3_mul_f(dcdy1, a));
+        V3 start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
+        V3 end_colour = v3_add_v3(c0, v3_mul_f(dcdy1, a));
 
-        v2_t start_uv = v2_add_v2(uv0, v2_mul_f(duvdy0, a));
-        v2_t end_uv = v2_add_v2(uv0, v2_mul_f(duvdy1, a));
+        V2 start_uv = v2_add_v2(uv0, v2_mul_f(duvdy0, a));
+        V2 end_uv = v2_add_v2(uv0, v2_mul_f(duvdy1, a));
 
         draw_textured_scanline(rt, start_x, end_x, y, z0, z1, start_w, end_w, start_colour, end_colour, start_uv, end_uv, texture);
     }
 }
 
-void draw_textured_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2, const texture_t* texture)
+void draw_textured_flat_top_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2, const Texture* texture)
 {
     // Sort the flat vertices left to right.
     if (vc0[0] > vc1[0])
@@ -709,17 +709,17 @@ void draw_textured_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1
         SWAP(float*, vc0, vc1);
     }
 
-    v4_t v0 = v4_read(vc0);
-    v4_t v1 = v4_read(vc1);
-    v4_t v2 = v4_read(vc2);
+    V4 v0 = v4_read(vc0);
+    V4 v1 = v4_read(vc1);
+    V4 v2 = v4_read(vc2);
 
-    const v3_t c0 = v3_read(vc0 + 4);
-    const v3_t c1 = v3_read(vc1 + 4);
-    const v3_t c2 = v3_read(vc2 + 4);
+    const V3 c0 = v3_read(vc0 + 4);
+    const V3 c1 = v3_read(vc1 + 4);
+    const V3 c2 = v3_read(vc2 + 4);
 
-    const v2_t uv0 = v2_read(vc0 + 7);
-    const v2_t uv1 = v2_read(vc1 + 7);
-    const v2_t uv2 = v2_read(vc2 + 7);
+    const V2 uv0 = v2_read(vc0 + 7);
+    const V2 uv1 = v2_read(vc1 + 7);
+    const V2 uv2 = v2_read(vc2 + 7);
 
     float inv_dy = 1 / (v2.y - v0.y);
 
@@ -735,11 +735,11 @@ void draw_textured_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1
     int start_y = (int)(ceil(v0.y - 0.5f));
     int end_y = (int)(ceil(v2.y - 0.5f));
 
-    v3_t dcdy0 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
-    v3_t dcdy1 = v3_mul_f(v3_sub_v3(c2, c1), inv_dy);
+    V3 dcdy0 = v3_mul_f(v3_sub_v3(c2, c0), inv_dy);
+    V3 dcdy1 = v3_mul_f(v3_sub_v3(c2, c1), inv_dy);
 
-    v2_t duvdy0 = v2_mul_f(v2_sub_v2(uv2, uv0), inv_dy);
-    v2_t duvdy1 = v2_mul_f(v2_sub_v2(uv2, uv1), inv_dy);
+    V2 duvdy0 = v2_mul_f(v2_sub_v2(uv2, uv0), inv_dy);
+    V2 duvdy1 = v2_mul_f(v2_sub_v2(uv2, uv1), inv_dy);
 
     for (int y = start_y; y < end_y; ++y) {
         // Must lerp for the vertex attributes to get them accurately.
@@ -762,17 +762,17 @@ void draw_textured_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1
         int start_x = (int)((x0 - 0.5f));
         int end_x = (int)((x1 - 0.5f));
 
-        v3_t start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
-        v3_t end_colour = v3_add_v3(c1, v3_mul_f(dcdy1, a));
+        V3 start_colour = v3_add_v3(c0, v3_mul_f(dcdy0, a));
+        V3 end_colour = v3_add_v3(c1, v3_mul_f(dcdy1, a));
 
-        v2_t start_uv = v2_add_v2(uv0, v2_mul_f(duvdy0, a));
-        v2_t end_uv = v2_add_v2(uv1, v2_mul_f(duvdy1, a));
+        V2 start_uv = v2_add_v2(uv0, v2_mul_f(duvdy0, a));
+        V2 end_uv = v2_add_v2(uv1, v2_mul_f(duvdy1, a));
 
         draw_textured_scanline(rt, start_x, end_x, y, z0, z1, start_w, end_w, start_colour, end_colour, start_uv, end_uv, texture);
     }
 }
 
-void draw_textured_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2, const texture_t* texture)
+void draw_textured_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2, const Texture* texture)
 {
     // TODO: why is it called vc0 (vertex copmonents) not just vertex.
 
@@ -840,7 +840,7 @@ void draw_textured_triangle(render_target_t* rt, float* vc0, float* vc1, float* 
     draw_textured_flat_bottom_triangle(rt, vc0, vc1, vc3, texture);
 }
 
-void draw_depth_scanline(depth_buffer_t* db, int x0, int x1, int y, float z0, float z1)
+void draw_depth_scanline(DepthBuffer* db, int x0, int x1, int y, float z0, float z1)
 {
 	// TODO: TEMP: Whilst no clipping.
 	if (y < 0) return;
@@ -891,12 +891,12 @@ void draw_depth_scanline(depth_buffer_t* db, int x0, int x1, int y, float z0, fl
 	}
 }
 
-void draw_depth_flat_bottom_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2)
+void draw_depth_flat_bottom_triangle(DepthBuffer* db, V4 v0, V4 v1, V4 v2)
 {
 	// Sort the flat vertices left to right.
 	if (v1.x > v2.x)
 	{
-        SWAP(v4_t, v1, v2);
+        SWAP(V4, v1, v2);
 	}
 
 	float inv_dy = 1 / (v2.y - v0.y);
@@ -936,12 +936,12 @@ void draw_depth_flat_bottom_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t 
 	}
 }
 
-void draw_depth_flat_top_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2)
+void draw_depth_flat_top_triangle(DepthBuffer* db, V4 v0, V4 v1, V4 v2)
 {
 	// Sort the flat vertices left to right.
 	if (v0.x > v1.x)
 	{
-        SWAP(v4_t, v0, v1);
+        SWAP(V4, v0, v1);
 	}
 
 	float inv_dy = 1 / (v2.y - v0.y);
@@ -978,22 +978,22 @@ void draw_depth_flat_top_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2)
 	}
 }
 
-void draw_depth_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2)
+void draw_depth_triangle(DepthBuffer* db, V4 v0, V4 v1, V4 v2)
 {
-	// TODO: I don't think we need w, so should make these v3_t.
+	// TODO: I don't think we need w, so should make these V3.
 
 	// Sort vertices in ascending order.
 	if (v0.y > v1.y)
 	{
-        SWAP(v4_t, v0, v1);
+        SWAP(V4, v0, v1);
 	}
 	if (v0.y > v2.y)
 	{
-        SWAP(v4_t, v0, v2);
+        SWAP(V4, v0, v2);
 	}
 	if (v1.y > v2.y)
 	{
-        SWAP(v4_t, v1, v2);
+        SWAP(V4, v1, v2);
 	}
 
 	// Handle if the triangle is already flat.
@@ -1014,7 +1014,7 @@ void draw_depth_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2)
 	// Linear interpolate for v3.
 	float t = (v1.y - v0.y) / (v2.y - v0.y);
 
-	v4_t v3 = {
+	V4 v3 = {
 		v0.x + (v2.x - v0.x) * t,
 		v1.y,
 		v0.z + (v2.z - v0.z) * t,
@@ -1025,12 +1025,12 @@ void draw_depth_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2)
 	draw_depth_flat_bottom_triangle(db, v0, v1, v3);
 }
 
-float calculate_diffuse_factor(const v3_t v, const v3_t n, const v3_t light_pos, float a, float b)
+float calculate_diffuse_factor(const V3 v, const V3 n, const V3 light_pos, float a, float b)
 {
 	// TODO: Comments, check maths etc.
 
 	// calculate the direction of the light to the vertex
-	v3_t light_dir = v3_sub_v3(light_pos, v);
+	V3 light_dir = v3_sub_v3(light_pos, v);
 
 
 	float light_distance = v3_size(light_dir);
@@ -1050,7 +1050,7 @@ float calculate_diffuse_factor(const v3_t v, const v3_t n, const v3_t light_pos,
 	return dp;
 }
 
-void project(const canvas_t* canvas, const m4_t projection_matrix, v4_t v, v4_t* out)
+void project(const Canvas* canvas, const M4 projection_matrix, V4 v, V4* out)
 {
 	// TODO: Rename view space to screen space?
 
@@ -1061,7 +1061,7 @@ void project(const canvas_t* canvas, const m4_t projection_matrix, v4_t v, v4_t*
 
 	// Apply the perspective projection matrix to project
 	// the 3D coordinates into 2D.
-	v4_t v_projected;
+	V4 v_projected;
 	m4_mul_v4(projection_matrix, v, &v_projected);
 
 	// Perform perspective divide to bring to NDC space.
@@ -1090,13 +1090,13 @@ void project(const canvas_t* canvas, const m4_t projection_matrix, v4_t v, v4_t*
 	out->w = inv_w;
 }
 
-void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene, const m4_t view_matrix)
+void model_to_view_space(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene, const M4 view_matrix)
 {
     // TODO: Could split this into multiple functions.
 
     // TODO: Should this function really be defined as transform stage as 
     //		 we also do the bounding sphere stuff.....
-    const mesh_base_t* mbs = scene->mesh_bases.bases;
+    const MeshBase* mbs = scene->mesh_bases.bases;
 
     int vsps_offset = 0;
     int vsns_offset = 0;
@@ -1104,15 +1104,15 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
     cecs_view_iter it = cecs_view_iter_create(ecs, render_view);
     while (cecs_view_iter_next(&it))
     {
-        mesh_instance_t* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
-        const transform_t* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
+        MeshInstance* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
+        const Transform* transforms = cecs_get_column(it, COMPONENT_TRANSFORM);
 
-        v3_t* vsps = frame_data->view_space_positions;
+        V3* vsps = frame_data->view_space_positions;
 
         for (int i = 0; i < it.num_entities; ++i)
         {            
-            mesh_instance_t* mi = &mis[i];
-            transform_t transform = transforms[i];
+            MeshInstance* mi = &mis[i];
+            Transform transform = transforms[i];
 
             // Save the offset to the start of the view space positions for the 
             // mesh instance.
@@ -1120,7 +1120,7 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
 
             // Calculate model matrix.
             // TODO: rotation or direction or eulers?
-            m4_t model_matrix;
+            M4 model_matrix;
             //m4_model_matrix(transform.position, transform.rotation, transform.scale, model_matrix);
 
             m4_model_matrix(
@@ -1130,20 +1130,20 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
                 transform.scale, 
                 model_matrix);
 
-            m4_t model_view_matrix;
+            M4 model_view_matrix;
             m4_mul_m4(view_matrix, model_matrix, model_view_matrix);
 
-            const mesh_base_t* mb = &mbs[mi->mb_id];
+            const MeshBase* mb = &mbs[mi->mb_id];
 
             // Update the centre of the bounding sphere.
-            v4_t view_space_centre;
+            V4 view_space_centre;
             m4_mul_v4(
                 model_view_matrix,
                 v3_to_v4(mb->centre, 1.f),
                 &view_space_centre);
 
             // Write out the bounding sphere.
-            bounding_sphere_t* bs = &mi->view_space_bounding_sphere;
+            BoundingSphere* bs = &mi->view_space_bounding_sphere;
             bs->centre = v4_xyz(view_space_centre);
 
             // Read the mesh base's object space positions and convert them to 
@@ -1151,8 +1151,8 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
 
             for (int j = 0; j < mb->num_positions; ++j)
             {
-                const v4_t osp = v3_to_v4(mb->object_space_positions[j], 1.f);
-                v4_t vsp;
+                const V4 osp = v3_to_v4(mb->object_space_positions[j], 1.f);
+                V4 vsp;
                 m4_mul_v4(model_view_matrix, osp, &vsp);
 
                 vsps[vsps_offset].x = vsp.x;
@@ -1164,12 +1164,12 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
         }
 
         // Convert object space normals to view space.
-        v3_t* vsns = frame_data->view_space_normals;
+        V3* vsns = frame_data->view_space_normals;
 
         for (int i = 0; i < it.num_entities; ++i)
         {
-            mesh_instance_t* mi = &mis[i];
-            transform_t transform = transforms[i];
+            MeshInstance* mi = &mis[i];
+            Transform transform = transforms[i];
 
             // Save the offset to the start of the view space positions for the 
             // mesh instance.
@@ -1177,7 +1177,7 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
 
             // Calculate normal matrix.
             // TODO: rotation or direction or eulers?
-            m4_t normal_matrix;
+            M4 normal_matrix;
             //m4_normal_matrix(transform.rotation, transform.scale, normal_matrix);
             m4_normal_matrix(
                 v3_lerp(transform.previous_rotation, transform.rotation, frame_data->physics_alpha),
@@ -1185,19 +1185,19 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
                 transform.scale,
                 normal_matrix);
 
-            m4_t view_normal_matrix;
+            M4 view_normal_matrix;
             m4_mul_m4(view_matrix, normal_matrix, view_normal_matrix);
 
-            const mesh_base_t* mb = &mbs[mi->mb_id];
+            const MeshBase* mb = &mbs[mi->mb_id];
 
             for (int j = 0; j < mb->num_normals; ++j)
             {
-                const v4_t osn = v3_to_v4(mb->object_space_normals[j], 0.f);
+                const V4 osn = v3_to_v4(mb->object_space_normals[j], 0.f);
 
-                v4_t vsn;
+                V4 vsn;
                 m4_mul_v4(view_normal_matrix, osn, &vsn);
 
-                v3_t normal = v3_normalised(v4_xyz(vsn));
+                V3 normal = v3_normalised(v4_xyz(vsn));
 
                 vsns[vsns_offset].x = normal.x;
                 vsns[vsns_offset].y = normal.y;
@@ -1209,22 +1209,22 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
 
         for (int i = 0; i < it.num_entities; ++i)
         {
-            mesh_instance_t* mi = &mis[i];
+            MeshInstance* mi = &mis[i];
 
             // Update the radius of each mesh instance bounding sphere.
-            const v3_t* vsps = frame_data->view_space_positions;
+            const V3* vsps = frame_data->view_space_positions;
 
             // Only update the bounding sphere if the scale is changed, otherwise
             // we don't need to update it. Note, we've already updated the centre
             // in the vsps calculation step!
             if (mi->has_scale_changed)
             {
-                bounding_sphere_t* bs = &mi->view_space_bounding_sphere;
-                v3_t view_space_centre = bs->centre;
+                BoundingSphere* bs = &mi->view_space_bounding_sphere;
+                V3 view_space_centre = bs->centre;
 
                 mi->has_scale_changed = 0;
 
-                const mesh_base_t* mb = &mbs[mi->mb_id];
+                const MeshBase* mb = &mbs[mi->mb_id];
 
                 // Calculate the new radius of the mi's bounding sphere.
                 float radius_squared = -1;
@@ -1232,8 +1232,8 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
                 const int end = mi->view_space_positions_offset + mb->num_positions;
                 for (int j = mi->view_space_positions_offset; j < end; ++j)
                 {
-                    v3_t v = vsps[j];
-                    v3_t between = v3_sub_v3(v, view_space_centre);
+                    V3 v = vsps[j];
+                    V3 between = v3_sub_v3(v, view_space_centre);
 
                     radius_squared = max(v3_size_sqrd(between), radius_squared);
                 }
@@ -1245,25 +1245,25 @@ void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* fram
     }	
 }
 
-void lights_world_to_view_space(cecs* ecs, cecs_view_id lighting_view, frame_data_t* frame_data, const scene_t* scene, const m4_t view_matrix)
+void lights_world_to_view_space(cecs* ecs, cecs_view_id lighting_view, FrameData* frame_data, const Scene* scene, const M4 view_matrix)
 {
 	// This could be made more efficient by having an array of input world
 	// space positions, however, we will never be able to support enough lights
 	// to make this worthwhile (i think).
 
 
-	v3_t* view_space_positions = frame_data->point_lights_view_space_positions;
+	V3* view_space_positions = frame_data->point_lights_view_space_positions;
 
     int vsps_offset = 0;
 
     cecs_view_iter it = cecs_view_iter_create(ecs, lighting_view);
     while (cecs_view_iter_next(&it))
     {
-        point_light_t* pls = cecs_get_column(it, COMPONENT_POINT_LIGHT);
+        PointLight* pls = cecs_get_column(it, COMPONENT_POINT_LIGHT);
 
         for (int i = 0; i < it.num_entities; ++i)
         {
-            v4_t v_view_space;
+            V4 v_view_space;
             m4_mul_v4(view_matrix, v3_to_v4(pls[i].position, 1.f),
                 &v_view_space);
 
@@ -1278,28 +1278,28 @@ void lights_world_to_view_space(cecs* ecs, cecs_view_id lighting_view, frame_dat
     }
 }
 
-void broad_phase_frustum_culling(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene, const view_frustum_t* view_frustum)
+void broad_phase_frustum_culling(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene, const ViewFrustum* view_frustum)
 {
 	// Performs broad phase frustum culling on the models, writes out the planes
 	// that need to be clipped against.
 	
-    mesh_instance_t* visible_mis = frame_data->visible_mis;
+    MeshInstance* visible_mis = frame_data->visible_mis;
 	int visible_mis_count = 0;
 	uint8_t* intersected_planes = frame_data->intersected_planes;
 	int intersected_planes_out_index = 0;
 
 	const int num_planes = view_frustum->planes_count;
-	const plane_t* planes = view_frustum->planes;
+	const Plane* planes = view_frustum->planes;
 
     cecs_view_iter it = cecs_view_iter_create(ecs, render_view);
     while (cecs_view_iter_next(&it))
     {
-        mesh_instance_t* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
+        MeshInstance* mis = cecs_get_column(it, COMPONENT_MESH_INSTANCE);
     
         for (int i = 0; i < it.num_entities; ++i)
         {
-            mesh_instance_t* mi = &mis[i];
-            const bounding_sphere_t bs = mi->view_space_bounding_sphere;
+            MeshInstance* mi = &mis[i];
+            const BoundingSphere bs = mi->view_space_bounding_sphere;
 
             // Store what planes need clipping against.
             int clip_against_plane[MAX_FRUSTUM_PLANES] = { 0 };
@@ -1345,13 +1345,13 @@ void broad_phase_frustum_culling(cecs* ecs, cecs_view_id render_view, frame_data
 	frame_data->num_visible_mis = visible_mis_count;
 }
 
-void cull_backfaces(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene)
+void cull_backfaces(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene)
 {
-	const mesh_base_t* mbs = scene->mesh_bases.bases;
+	const MeshBase* mbs = scene->mesh_bases.bases;
 
 	// Determines what faces are facing the camera and prepares
 	// the vertex data for the lighting calculations.
-	mesh_instance_t* visible_mis = frame_data->visible_mis;
+	MeshInstance* visible_mis = frame_data->visible_mis;
 	const int num_visible_mis = frame_data->num_visible_mis;
 
 	int* front_face_indices = frame_data->front_face_indices;
@@ -1361,11 +1361,11 @@ void cull_backfaces(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_dat
 	{
 		int front_faces = 0;
 
-		mesh_instance_t* mi = &visible_mis[i];
-		const mesh_base_t* mb = &mbs[mi->mb_id];
+		MeshInstance* mi = &visible_mis[i];
+		const MeshBase* mb = &mbs[mi->mb_id];
 
 		const int* position_indices = mb->position_indices;
-	    const v3_t* vsps = frame_data->view_space_positions + mi->view_space_positions_offset;
+	    const V3* vsps = frame_data->view_space_positions + mi->view_space_positions_offset;
 
 		for (int j = 0; j < mb->num_faces; ++j)
 		{
@@ -1401,9 +1401,9 @@ void light_front_faces(
     cecs* ecs, 
     cecs_view_id render_view, 
     cecs_view_id lighting_view, 
-    frame_data_t* frame_data, 
-    scene_t* scene, 
-    const v3_t ambient)
+    FrameData* frame_data, 
+    Scene* scene, 
+    const V3 ambient)
 {
 	/*
 	
@@ -1449,31 +1449,31 @@ void light_front_faces(
 	// Input
 	//const Lights* lights = &scene->lights;
     //const ComponentList* point_lights_list = &scene->lights.point_lights;
-    //const point_light_t* point_lights = (point_light_t*)point_lights_list->elements;
-	const mesh_base_t* mbs = scene->mesh_bases.bases;
+    //const PointLight* point_lights = (PointLight*)point_lights_list->elements;
+	const MeshBase* mbs = scene->mesh_bases.bases;
 
 	const int* front_face_indices = frame_data->front_face_indices;
-	const v3_t* vsps = frame_data->view_space_positions;
-	const v3_t* vsns = frame_data->view_space_normals;
-	const v3_t* point_light_vsps = frame_data->point_lights_view_space_positions;
+	const V3* vsps = frame_data->view_space_positions;
+	const V3* vsns = frame_data->view_space_normals;
+	const V3* point_light_vsps = frame_data->point_lights_view_space_positions;
 
-	const mesh_instance_t* mis = frame_data->visible_mis;
+	const MeshInstance* mis = frame_data->visible_mis;
 	const int num_visible_mis = frame_data->num_visible_mis;
 	
 	// Output
 	int out_index = 0;
 
-    // TODO: float* or v3_t*
-	v3_t* vertex_lighting = frame_data->vertex_lighting;
+    // TODO: float* or V3*
+	V3* vertex_lighting = frame_data->vertex_lighting;
 
 	int front_faces_offset = 0;
 
 	for (int i = 0; i < num_visible_mis; ++i)
 	{
-		const mesh_instance_t* mi = &mis[i];
-		const mesh_base_t* mb = &mbs[mi->mb_id];
+		const MeshInstance* mi = &mis[i];
+		const MeshBase* mb = &mbs[mi->mb_id];
 
-		const v3_t* vertex_albedos = mi->vertex_alebdos;
+		const V3* vertex_albedos = mi->vertex_alebdos;
 
 		const int vsp_offset = mi->view_space_positions_offset;
 		const int vsn_offset = mi->view_space_normals_offset;
@@ -1484,14 +1484,14 @@ void light_front_faces(
 
 			for (int vi = 0; vi < STRIDE_FACE_VERTICES; ++vi)
 			{
-				const v3_t point = vsps[vsp_offset + mb->position_indices[face_index + vi]];
-				const v3_t normal = vsns[vsn_offset + mb->normal_indices[face_index + vi]];
+				const V3 point = vsps[vsp_offset + mb->position_indices[face_index + vi]];
+				const V3 normal = vsns[vsn_offset + mb->normal_indices[face_index + vi]];
 
                 // Albedos are stored per vertex. 
                 // TODO: How do these line up when we cull faces????? They dont..... do they? could cause issues when setting albedo for specific vertices....
 
-                const v3_t albedo = vertex_albedos[j * STRIDE_FACE_VERTICES + vi];
-				v3_t diffuse = { 0 };
+                const V3 albedo = vertex_albedos[j * STRIDE_FACE_VERTICES + vi];
+				V3 diffuse = { 0 };
                 
                 int pl_vsps_offset = 0;
 
@@ -1500,21 +1500,21 @@ void light_front_faces(
                 cecs_view_iter it = cecs_view_iter_create(ecs, lighting_view);
                 while (cecs_view_iter_next(&it))
                 {
-                    point_light_t* pls = cecs_get_column(it, COMPONENT_POINT_LIGHT);
+                    PointLight* pls = cecs_get_column(it, COMPONENT_POINT_LIGHT);
 
                     for (int i = 0; i < it.num_entities; ++i)
                     {
-                        const v3_t pl_vsp = point_light_vsps[pl_vsps_offset];
+                        const V3 pl_vsp = point_light_vsps[pl_vsps_offset];
                         ++pl_vsps_offset;
 
-                        const point_light_t* pl = &pls[i];
+                        const PointLight* pl = &pls[i];
 
                         const float a = 0.1f / pl->strength;
                         const float b = 0.01f / pl->strength;
 
                         const float df = calculate_diffuse_factor(point, normal, pl_vsp, a, b);
 
-                        const v3_t colour = v3_mul_f(pl->colour, df);
+                        const V3 colour = v3_mul_f(pl->colour, df);
 
                         v3_add_eq_v3(&diffuse, colour);
                     }
@@ -1524,16 +1524,16 @@ void light_front_faces(
                 /*
 				for (int pl_index = 0; pl_index < point_lights_list->count; ++pl_index)
 				{
-					const point_light_t* pl = &point_lights[pl_index];
+					const PointLight* pl = &point_lights[pl_index];
 
-					const v3_t pl_vsp = v3_read(point_light_vsps + pl_index * STRIDE_POSITION);
+					const V3 pl_vsp = v3_read(point_light_vsps + pl_index * STRIDE_POSITION);
 
 					const float a = 0.1f / pl->strength;
 					const float b = 0.01f / pl->strength;
 
 					const float df = calculate_diffuse_factor(point, normal, pl_vsp, a, b);
                     
-					const v3_t colour = v3_mul_f(pl->colour, df);
+					const V3 colour = v3_mul_f(pl->colour, df);
 
 					v3_add_eq_v3(&diffuse, colour);
 				}*/
@@ -1541,7 +1541,7 @@ void light_front_faces(
 				// TODO: shadow casting lights etc.
 
 				// Clamp diffuse contribution to a valid range 0-1. 
-                v3_t light = v3_mul_v3(albedo, v3_add_v3(diffuse, ambient));
+                V3 light = v3_mul_v3(albedo, v3_add_v3(diffuse, ambient));
 
 
 				// TODO: Do we clamp here? How does it work with shadows..
@@ -1577,19 +1577,19 @@ void light_front_faces(
 	}
 }
 
-void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene)
+void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene)
 {
     // TODO: Comments on how the data is packed together.
 
 	// Input
-	const mesh_instance_t* mis = frame_data->visible_mis;
-	const mesh_base_t* mbs = scene->mesh_bases.bases;
+	const MeshInstance* mis = frame_data->visible_mis;
+	const MeshBase* mbs = scene->mesh_bases.bases;
 	
 	const int* front_face_indices = frame_data->front_face_indices;
 
 	const int num_visible_mis = frame_data->num_visible_mis;
 
-	const v3_t* vertex_lighting = frame_data->vertex_lighting;
+	const V3* vertex_lighting = frame_data->vertex_lighting;
     int vertex_lighting_in = 0;
 
 	// Output
@@ -1600,15 +1600,15 @@ void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, frame_data_t* fra
 
 	for (int i = 0; i < num_visible_mis; ++i)
 	{
-		const mesh_instance_t* mi = &mis[i];
-		const mesh_base_t* mb = &mbs[mi->mb_id];
+		const MeshInstance* mi = &mis[i];
+		const MeshBase* mb = &mbs[mi->mb_id];
 
 		const int* position_indices = mb->position_indices;
 		const int vsp_offset = mi->view_space_positions_offset;
-	    const v3_t* vsps = frame_data->view_space_positions + vsp_offset;
+	    const V3* vsps = frame_data->view_space_positions + vsp_offset;
 
 		const int* uv_indices = mb->uv_indices;
-		const v2_t* uvs = mb->uvs;
+		const V2* uvs = mb->uvs;
 
         // Only write out UVs if the mesh is textured.
         if (mi->texture_id != -1)
@@ -1617,19 +1617,19 @@ void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, frame_data_t* fra
             {
                 const int face_index = front_face_indices[j + front_faces_offset] * STRIDE_FACE_VERTICES;
 
-                const v3_t p0 = vsps[position_indices[face_index]];
-                const v3_t p1 = vsps[position_indices[face_index + 1]];
-                const v3_t p2 = vsps[position_indices[face_index + 2]];
+                const V3 p0 = vsps[position_indices[face_index]];
+                const V3 p1 = vsps[position_indices[face_index + 1]];
+                const V3 p2 = vsps[position_indices[face_index + 2]];
 
                 // TODO: Lighting is not the nicest name for this.
-                const v3_t lighting0 = vertex_lighting[vertex_lighting_in];
-                const v3_t lighting1 = vertex_lighting[vertex_lighting_in + 1];
-                const v3_t lighting2 = vertex_lighting[vertex_lighting_in + 2];
+                const V3 lighting0 = vertex_lighting[vertex_lighting_in];
+                const V3 lighting1 = vertex_lighting[vertex_lighting_in + 1];
+                const V3 lighting2 = vertex_lighting[vertex_lighting_in + 2];
                 vertex_lighting_in += STRIDE_FACE_VERTICES;
 
-                const v2_t uv0 = uvs[uv_indices[face_index]];
-                const v2_t uv1 = uvs[uv_indices[face_index + 1]];
-                const v2_t uv2 = uvs[uv_indices[face_index + 2]];
+                const V2 uv0 = uvs[uv_indices[face_index]];
+                const V2 uv1 = uvs[uv_indices[face_index + 1]];
+                const V2 uv2 = uvs[uv_indices[face_index + 2]];
 
                 // Write out the vertices.
 #define WRITE_VERTEX(p, l, uv) \
@@ -1656,14 +1656,14 @@ void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, frame_data_t* fra
             {
                 const int face_index = front_face_indices[j + front_faces_offset] * STRIDE_FACE_VERTICES;
 
-                const v3_t p0 = vsps[position_indices[face_index]];
-                const v3_t p1 = vsps[position_indices[face_index + 1]];
-                const v3_t p2 = vsps[position_indices[face_index + 2]];
+                const V3 p0 = vsps[position_indices[face_index]];
+                const V3 p1 = vsps[position_indices[face_index + 1]];
+                const V3 p2 = vsps[position_indices[face_index + 2]];
 
                 // TODO: Lighting is not the nicest name for this.
-                const v3_t lighting0 = vertex_lighting[vertex_lighting_in];
-                const v3_t lighting1 = vertex_lighting[vertex_lighting_in + 1];
-                const v3_t lighting2 = vertex_lighting[vertex_lighting_in + 2];
+                const V3 lighting0 = vertex_lighting[vertex_lighting_in];
+                const V3 lighting1 = vertex_lighting[vertex_lighting_in + 1];
+                const V3 lighting2 = vertex_lighting[vertex_lighting_in + 2];
                 vertex_lighting_in += STRIDE_FACE_VERTICES;
 
                 // Write out the vertices.
@@ -1691,15 +1691,15 @@ void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, frame_data_t* fra
 
 void clip_project_and_draw(
     cecs_view_id render_view,
-	renderer_t* renderer,
-	render_target_t* rt,
-	frame_data_t* frame_data,
-	scene_t* scene,
-    const resources_t* resources)
+	Renderer* renderer,
+	RenderTarget* rt,
+	FrameData* frame_data,
+	Scene* scene,
+    const Resources* resources)
 {
 	// Input
-	const mesh_instance_t* mis = frame_data->visible_mis;
-	const mesh_base_t* mbs = scene->mesh_bases.bases;
+	const MeshInstance* mis = frame_data->visible_mis;
+	const MeshBase* mbs = scene->mesh_bases.bases;
 
 	const int num_visible_mis = frame_data->num_visible_mis;
 
@@ -1715,8 +1715,8 @@ void clip_project_and_draw(
 
 	for (int i = 0; i < num_visible_mis; ++i)
 	{
-		const mesh_instance_t* mi = &mis[i];
-		const mesh_base_t* mb = &mbs[mi->mb_id];
+		const MeshInstance* mi = &mis[i];
+		const MeshBase* mb = &mbs[mi->mb_id];
 
 		const uint8_t num_planes_to_clip_against = intersected_planes[intersected_planes_index++];
         
@@ -1765,7 +1765,7 @@ void clip_project_and_draw(
 
 			for (int j = 0; j < num_planes_to_clip_against; ++j)
 			{
-				const plane_t* plane = &renderer->settings.view_frustum.planes[intersected_planes[intersected_planes_index++]];
+				const Plane* plane = &renderer->settings.view_frustum.planes[intersected_planes[intersected_planes_index++]];
 				
 				// Reset the index to write out to.
 				index_out = 0;
@@ -1859,16 +1859,16 @@ void clip_project_and_draw(
                         const float* ov0 = temp_clipped_faces_in + index_ov0;
                         const float* ov1 = temp_clipped_faces_in + index_ov1;
 
-						const v3_t ip0 = v3_read(iv0);
-						const v3_t op0 = v3_read(ov0);
-						const v3_t op1 = v3_read(ov1);
+						const V3 ip0 = v3_read(iv0);
+						const V3 op0 = v3_read(ov0);
+						const V3 op1 = v3_read(ov1);
 
 						// Copy the inside vertex.
 						memcpy(temp_clipped_faces_out + index_out, iv0, VERTEX_COMPONENTS * sizeof(float));
 						index_out += VERTEX_COMPONENTS;
 
 						// Lerp for the first new vertex.
-						v3_t p0;
+						V3 p0;
 						float t = line_intersect_plane(ip0, op0, plane, &p0);
 
 						temp_clipped_faces_out[index_out++] = p0.x;
@@ -1884,7 +1884,7 @@ void clip_project_and_draw(
 						}
 
 						// Lerp for the second vertex.
-						v3_t p1;
+						V3 p1;
 						t = line_intersect_plane(ip0, op1, plane, &p1);
 
 						temp_clipped_faces_out[index_out++] = p1.x;
@@ -1911,9 +1911,9 @@ void clip_project_and_draw(
                         const float* iv1 = temp_clipped_faces_in + index_iv1;
                         const float* ov0 = temp_clipped_faces_in + index_ov0;
 
-						const v3_t ip0 = v3_read(iv0);
-						const v3_t ip1 = v3_read(iv1);
-						const v3_t op0 = v3_read(ov0);
+						const V3 ip0 = v3_read(iv0);
+						const V3 ip1 = v3_read(iv1);
+						const V3 op0 = v3_read(ov0);
 
 						// Copy the first inside vertex.
 						memcpy(temp_clipped_faces_out + index_out, iv0, VERTEX_COMPONENTS * sizeof(float));
@@ -1924,7 +1924,7 @@ void clip_project_and_draw(
 						index_out += VERTEX_COMPONENTS;
 
 						// Lerp for the first new vertex.
-						v3_t p0;
+						V3 p0;
 						float t = line_intersect_plane(ip0, op0, plane, &p0);
 
                         // We will reuse this vertex for the second triangle, so copy it's index.
@@ -1952,7 +1952,7 @@ void clip_project_and_draw(
 						}
 
 						// Lerp for the second new point.
-						v3_t p1;
+						V3 p1;
 						t = line_intersect_plane(ip1, op0, plane, &p1);
 						
 						temp_clipped_faces_out[index_out++] = p1.x;
@@ -2005,10 +2005,10 @@ void clip_project_and_draw(
 }
 
 void project_and_draw_clipped(
-	renderer_t* renderer,
-	render_target_t* rt,
-	frame_data_t* frame_data,
-	const mesh_instance_t* mi
+	Renderer* renderer,
+	RenderTarget* rt,
+	FrameData* frame_data,
+	const MeshInstance* mi
 	)
 {
     // TODO: I would at least like to project everything at once if we're going to do it like this right??
@@ -2035,11 +2035,11 @@ void project_and_draw_clipped(
 		const float* v1 = face + INPUT_VERTEX_COMPONENTS;
 		const float* v2 = face + INPUT_VERTEX_COMPONENTS * 2;
 
-		const v4_t p0 = v3_read_to_v4(v0, 1.f);
-		const v4_t p1 = v3_read_to_v4(v1, 1.f);
-		const v4_t p2 = v3_read_to_v4(v2, 1.f);
+		const V4 p0 = v3_read_to_v4(v0, 1.f);
+		const V4 p1 = v3_read_to_v4(v1, 1.f);
+		const V4 p2 = v3_read_to_v4(v2, 1.f);
 
-		v4_t ssp0, ssp1, ssp2;
+		V4 ssp0, ssp1, ssp2;
 		project(&rt->canvas, renderer->settings.projection_matrix, p0, &ssp0);
 		project(&rt->canvas, renderer->settings.projection_matrix, p1, &ssp1);
 		project(&rt->canvas, renderer->settings.projection_matrix, p2, &ssp2);
@@ -2073,11 +2073,11 @@ void project_and_draw_clipped(
 }
 
 void project_and_draw_clipped_textured(
-    renderer_t* renderer,
-    render_target_t* rt,
-    frame_data_t* frame_data,
-    const mesh_instance_t* mi,
-    const texture_t* texture
+    Renderer* renderer,
+    RenderTarget* rt,
+    FrameData* frame_data,
+    const MeshInstance* mi,
+    const Texture* texture
 )
 {
     // TODO: Almost identical to project_and_draw_clipped..... maybe not worth
@@ -2106,11 +2106,11 @@ void project_and_draw_clipped_textured(
         const float* v1 = face + INPUT_VERTEX_COMPONENTS;
         const float* v2 = face + INPUT_VERTEX_COMPONENTS * 2;
 
-        const v4_t p0 = v3_read_to_v4(v0, 1.f);
-        const v4_t p1 = v3_read_to_v4(v1, 1.f);
-        const v4_t p2 = v3_read_to_v4(v2, 1.f);
+        const V4 p0 = v3_read_to_v4(v0, 1.f);
+        const V4 p1 = v3_read_to_v4(v1, 1.f);
+        const V4 p2 = v3_read_to_v4(v2, 1.f);
 
-        v4_t ssp0, ssp1, ssp2;
+        V4 ssp0, ssp1, ssp2;
         project(&rt->canvas, renderer->settings.projection_matrix, p0, &ssp0);
         project(&rt->canvas, renderer->settings.projection_matrix, p1, &ssp1);
         project(&rt->canvas, renderer->settings.projection_matrix, p2, &ssp2);
@@ -2140,7 +2140,7 @@ void project_and_draw_clipped_textured(
         // TODO: Would be nice to do this elsewhere
         // Scale the uvs to the size of the texture to avoid doing it 
         // per pixel. 
-        // TODO: This could be done via a mesh_instance_t set texture
+        // TODO: This could be done via a MeshInstance set texture
         // function?
         int w = texture->width - 1;
         int h = texture->height - 1;
@@ -2161,10 +2161,10 @@ void render(
     cecs* ecs,
     cecs_view_id render_view,
     cecs_view_id lighting_view,
-	renderer_t* renderer,
-	scene_t* scene,
-	const resources_t* resources,
-	const m4_t view_matrix)
+	Renderer* renderer,
+	Scene* scene,
+	const Resources* resources,
+	const M4 view_matrix)
 {
     // This render function is using the render and lighting 'views' honestly
     // they're more like views at this point.
@@ -2217,7 +2217,7 @@ void render(
     renderer->target.canvas.pixels[centre] = 0x00FF0000;
 }
 /*
-void update_depth_maps(renderer_t* renderer, const scene_t* scene)
+void update_depth_maps(Renderer* renderer, const Scene* scene)
 {
 
 	// TODO: To avoid recalculating shadows for each mesh. We should only do it for ones that have moved.
@@ -2241,18 +2241,18 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 
 	for (int i = 0; i < pls->count; ++i)
 	{
-		depth_buffer_t* depth_map = &pls->depth_maps[i];
+		DepthBuffer* depth_map = &pls->depth_maps[i];
 		depth_buffer_fill(depth_map, 1.f);
 
 		int pos_i = i * STRIDE_POSITION;
 
-		v3_t pos = v3_read(pls->world_space_positions + pos_i);
+		V3 pos = v3_read(pls->world_space_positions + pos_i);
 		
 		// TODO: TEMP, hardcoded.
-		v3_t dir = { 0, 0, -1 };
+		V3 dir = { 0, 0, -1 };
 		
 		// Create MV matrix for light.
-		m4_t view;
+		M4 view;
 		look_at(v3_mul_f(pos, -1.f), v3_mul_f(dir, -1.f), view);
 
 		// 90 degrees will give us a face of the cube map we want.
@@ -2264,7 +2264,7 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 		float near_plane = 1.f;
 		float far_plane = 100.f; // TODO: Defined from strength of point light? with attenuation taken into account?
 
-		m4_t proj;
+		M4 proj;
 		m4_projection(fov, aspect_ratio, near_plane, far_plane, proj);
 		
 		const int mis_count = models->mis_count;
@@ -2293,7 +2293,7 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 			// Calculate the new model matrix from the mi's transform.
 			int transform_index = j * STRIDE_MI_TRANSFORM;
 			
-			m4_t model_matrix;
+			M4 model_matrix;
 			m4_model_matrix(
 				v3_read(mis_transforms + transform_index), 
 				v3_read(mis_transforms + transform_index + 3), 
@@ -2301,7 +2301,7 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 				model_matrix
 			);
 
-			m4_t model_view;
+			M4 model_view;
 			m4_mul_m4(view, model_matrix, model_view);
 
 			for (int k = 0; k < models->mbs_faces_counts[mb_index]; ++k)
@@ -2318,9 +2318,9 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 				const int index_parts_v2 = index_v2 * STRIDE_POSITION;
 
 				// Get the vertices from the face indices.
-				v4_t osp0 = v3_read_to_v4(object_space_positions + index_parts_v0, 1.f);
-				v4_t osp1 = v3_read_to_v4(object_space_positions + index_parts_v1, 1.f);
-				v4_t osp2 = v3_read_to_v4(object_space_positions + index_parts_v2, 1.f);
+				V4 osp0 = v3_read_to_v4(object_space_positions + index_parts_v0, 1.f);
+				V4 osp1 = v3_read_to_v4(object_space_positions + index_parts_v1, 1.f);
+				V4 osp2 = v3_read_to_v4(object_space_positions + index_parts_v2, 1.f);
 
 				// TODO: For this, refactor to do model view transformation first per vertex
 				//		 so we're not doing it multiple times with the indexed rendering. 
@@ -2328,16 +2328,16 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 				// TODO: This should all work the same as the normal rendering really, frustum
 				//		 culling and clipping etc.
 
-				v4_t vsp0, vsp1, vsp2;
+				V4 vsp0, vsp1, vsp2;
 				m4_mul_v4(model_view, osp0, &vsp0);
 				m4_mul_v4(model_view, osp1, &vsp1);
 				m4_mul_v4(model_view, osp2, &vsp2);
 
-				v3_t vsp0_v3 = v4_xyz(vsp0);
-				v3_t vsp1_v3 = v4_xyz(vsp1);
-				v3_t vsp2_v3 = v4_xyz(vsp2);
+				V3 vsp0_v3 = v4_xyz(vsp0);
+				V3 vsp1_v3 = v4_xyz(vsp1);
+				V3 vsp2_v3 = v4_xyz(vsp2);
 
-				v3_t face_normal = v3_normalised(cross(v3_sub_v3(vsp1_v3, vsp0_v3), v3_sub_v3(vsp2_v3, vsp0_v3)));
+				V3 face_normal = v3_normalised(cross(v3_sub_v3(vsp1_v3, vsp0_v3), v3_sub_v3(vsp2_v3, vsp0_v3)));
 
 				// Only fill depth map from back faces, need the normal so doing this manually.
 				if (dot(vsp0_v3, face_normal) <= 0)
@@ -2348,7 +2348,7 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 
 				// The perspective projection transforms the coordinates into clip space, before the perpsective divide.
 				// which just converts the homogeneous coordinates to cartesian ones. 
-				v4_t clip0, clip1, clip2;
+				V4 clip0, clip1, clip2;
 				m4_mul_v4(proj, vsp0, &clip0);
 				m4_mul_v4(proj, vsp1, &clip1);
 				m4_mul_v4(proj, vsp2, &clip2);
@@ -2369,21 +2369,21 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 				const float inv_w1 = 1.0f / clip1.w;
 				const float inv_w2 = 1.0f / clip2.w;
 				
-				v4_t ndc0 = {
+				V4 ndc0 = {
 					clip0.x * inv_w0,
 					clip0.y * inv_w0,
 					clip0.z * inv_w0,
 					inv_w0
 				};
 
-				v4_t ndc1 = {
+				V4 ndc1 = {
 					clip1.x * inv_w1,
 					clip1.y * inv_w1,
 					clip1.z * inv_w1,
 					inv_w1
 				};
 
-				v4_t ndc2 = {
+				V4 ndc2 = {
 					clip2.x * inv_w2,
 					clip2.y * inv_w2,
 					clip2.z * inv_w2,
@@ -2391,21 +2391,21 @@ void update_depth_maps(renderer_t* renderer, const scene_t* scene)
 				};
 
 				// Convert NDC to screen space by first converting to 0-1 in all axis.
-				v4_t ssp0 = {
+				V4 ssp0 = {
 					(ndc0.x + 1) * 0.5f * depth_map->width,
 					(-ndc0.y + 1) * 0.5f * depth_map->height,
 					(ndc0.z + 1) * 0.5f,
 					inv_w0
 				};
 
-				v4_t ssp1 = {
+				V4 ssp1 = {
 					(ndc1.x + 1) * 0.5f * depth_map->width,
 					(-ndc1.y + 1) * 0.5f * depth_map->height,
 					(ndc1.z + 1) * 0.5f,
 					inv_w1
 				};
 
-				v4_t ssp2 = {
+				V4 ssp2 = {
 					(ndc2.x + 1) * 0.5f * depth_map->width,
 					(-ndc2.y + 1) * 0.5f * depth_map->height,
 					(ndc2.z + 1) * 0.5f,

--- a/engine/engine/renderer/render.h
+++ b/engine/engine/renderer/render.h
@@ -31,111 +31,111 @@
 // TODO: Refactor and comments etc.
 
 void debug_draw_point_lights(
-    canvas_t* canvas,
+    Canvas* canvas,
     const cecs* ecs,
     const cecs_view_id lighting_view,
-    const frame_data_t* frame_data,
-    const render_settings_t* settings
+    const FrameData* frame_data,
+    const RenderSettings* settings
 );
 
-void debug_draw_view_space_point(canvas_t* canvas, const render_settings_t* settings, v3_t point, int colour);
-void debug_draw_normals(canvas_t* canvas, const frame_data_t* frame_data, const render_settings_t* settings, const scene_t* scene);
+void debug_draw_view_space_point(Canvas* canvas, const RenderSettings* settings, V3 point, int colour);
+void debug_draw_normals(Canvas* canvas, const FrameData* frame_data, const RenderSettings* settings, const Scene* scene);
 
-/*void debug_draw_point_lights(canvas_t* canvas, const render_settings_t* settings, PointLights* point_lights);
-void debug_draw_bounding_spheres(canvas_t* canvas, const render_settings_t* settings, const Models* models, const m4_t view_matrix);
+/*void debug_draw_point_lights(Canvas* canvas, const RenderSettings* settings, PointLights* point_lights);
+void debug_draw_bounding_spheres(Canvas* canvas, const RenderSettings* settings, const Models* models, const M4 view_matrix);
 */
-void debug_draw_world_space_point(canvas_t* canvas, const render_settings_t* settings, v3_t point, const m4_t view_matrix, int colour);
-void debug_draw_world_space_line(canvas_t* canvas, const render_settings_t* settings, const m4_t view_matrix, v3_t v0, v3_t v1, v3_t colour);
+void debug_draw_world_space_point(Canvas* canvas, const RenderSettings* settings, V3 point, const M4 view_matrix, int colour);
+void debug_draw_world_space_line(Canvas* canvas, const RenderSettings* settings, const M4 view_matrix, V3 v0, V3 v1, V3 colour);
 
 
 
 // TODO: Split these functions into sections.
 
 // TODO: Not sure where to put this?
-float calculate_diffuse_factor(v3_t v, v3_t n, v3_t light_pos, float a, float b);
+float calculate_diffuse_factor(V3 v, V3 n, V3 light_pos, float a, float b);
 
 // SECTION: Triangle rasterisation.
-void draw_scanline(render_target_t* rt, 
+void draw_scanline(RenderTarget* rt, 
 	int x0, int x1, 
 	int y, 
 	float z0, float z1, 
 	float w0, float w1, 
-	v3_t ac0, v3_t ac1);
+	V3 ac0, V3 ac1);
 
-void draw_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2);
-void draw_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2);
-void draw_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2);
+void draw_flat_bottom_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2);
+void draw_flat_top_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2);
+void draw_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2);
 
 // TODO: Rename?
-void draw_textured_scanline(render_target_t* rt, int x0, int x1, int y, float z0, float z1, float w0, float w1, v3_t c0, v3_t c1, const v2_t uv0, const v2_t uv1, const texture_t* texture);
-void draw_textured_flat_bottom_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2, const texture_t* texture);
-void draw_textured_flat_top_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2, const texture_t* texture);
-void draw_textured_triangle(render_target_t* rt, float* vc0, float* vc1, float* vc2, const texture_t* texture);
+void draw_textured_scanline(RenderTarget* rt, int x0, int x1, int y, float z0, float z1, float w0, float w1, V3 c0, V3 c1, const V2 uv0, const V2 uv1, const Texture* texture);
+void draw_textured_flat_bottom_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2, const Texture* texture);
+void draw_textured_flat_top_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2, const Texture* texture);
+void draw_textured_triangle(RenderTarget* rt, float* vc0, float* vc1, float* vc2, const Texture* texture);
 
 // TODO: Comments etc.
-void draw_depth_scanline(depth_buffer_t* db, int x0, int x1, int y, float z0, float z1);
-void draw_depth_flat_bottom_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2);
-void draw_depth_flat_top_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2);
-void draw_depth_triangle(depth_buffer_t* db, v4_t v0, v4_t v1, v4_t v2);
+void draw_depth_scanline(DepthBuffer* db, int x0, int x1, int y, float z0, float z1);
+void draw_depth_flat_bottom_triangle(DepthBuffer* db, V4 v0, V4 v1, V4 v2);
+void draw_depth_flat_top_triangle(DepthBuffer* db, V4 v0, V4 v1, V4 v2);
+void draw_depth_triangle(DepthBuffer* db, V4 v0, V4 v1, V4 v2);
 
 // SECTION: Rendering Pipeline.
-void project(const canvas_t* canvas, const m4_t projection_matrix, v4_t v, v4_t* out);
+void project(const Canvas* canvas, const M4 projection_matrix, V4 v, V4* out);
 
 
 
 
 // REFACTORED PIPELINE
 
-void model_to_view_space(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene, const m4_t view_matrix);
-void lights_world_to_view_space(cecs* ecs, cecs_view_id lighting_view, frame_data_t* frame_data, const scene_t* scene, const m4_t view_matrix);
-void broad_phase_frustum_culling(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene, const view_frustum_t* view_frustum);
-void cull_backfaces(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene);
+void model_to_view_space(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene, const M4 view_matrix);
+void lights_world_to_view_space(cecs* ecs, cecs_view_id lighting_view, FrameData* frame_data, const Scene* scene, const M4 view_matrix);
+void broad_phase_frustum_culling(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene, const ViewFrustum* view_frustum);
+void cull_backfaces(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene);
 
 void light_front_faces(
     cecs* ecs, 
     cecs_view_id render_view, 
     cecs_view_id lighting_view, 
-    frame_data_t* frame_data, 
-    scene_t* scene, 
-    const v3_t ambient
+    FrameData* frame_data, 
+    Scene* scene, 
+    const V3 ambient
 );
 
-void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, frame_data_t* frame_data, scene_t* scene);
+void prepare_for_clipping(cecs* ecs, cecs_view_id render_view, FrameData* frame_data, Scene* scene);
 void clip_project_and_draw(
     cecs_view_id render_view,
-	renderer_t* renderer,
-	render_target_t* rt,
-	frame_data_t* frame_data,
-	scene_t* scene,
-    const resources_t* resources);
+	Renderer* renderer,
+	RenderTarget* rt,
+	FrameData* frame_data,
+	Scene* scene,
+    const Resources* resources);
 
 // TODO: Hate this name.
 void project_and_draw_clipped(
-    renderer_t* renderer,
-    render_target_t* rt,
-    frame_data_t* frame_data,
-    const mesh_instance_t* mi);
+    Renderer* renderer,
+    RenderTarget* rt,
+    FrameData* frame_data,
+    const MeshInstance* mi);
 
 void project_and_draw_clipped_textured(
-    renderer_t* renderer,
-    render_target_t* rt,
-    frame_data_t* frame_data,
-    const mesh_instance_t* mi,
-    const texture_t* texture);
+    Renderer* renderer,
+    RenderTarget* rt,
+    FrameData* frame_data,
+    const MeshInstance* mi,
+    const Texture* texture);
 
 void render(
     cecs* ecs,
     cecs_view_id render_view,
     cecs_view_id lighting_view,
-    renderer_t* renderer,
-    scene_t* scene,
-    const resources_t* resources,
-    const m4_t view_matrix);
+    Renderer* renderer,
+    Scene* scene,
+    const Resources* resources,
+    const M4 view_matrix);
 
 // TEMP
 
 
-void update_depth_maps(renderer_t* renderer, const scene_t* scene);
+void update_depth_maps(Renderer* renderer, const Scene* scene);
 
 
 #endif

--- a/engine/engine/renderer/render_settings.h
+++ b/engine/engine/renderer/render_settings.h
@@ -8,7 +8,7 @@
 #include "maths/matrix4.h"
 #include "maths/utils.h"
 
-// TODO: render_settings_t is a bit off. We also want to store the view frustum
+// TODO: RenderSettings is a bit off. We also want to store the view frustum
 //		 as this won't change unless fov changes. This stuff is slightly 
 //		 different to the fov/near/farplane.
 //			
@@ -24,13 +24,13 @@ typedef struct
 
 	float far_plane;
 
-	// TODO: Should these go to the renderer_t?
-	m4_t projection_matrix;
-	view_frustum_t view_frustum; // TODO: Definitely should go in the renderer.
+	// TODO: Should these go to the Renderer?
+	M4 projection_matrix;
+	ViewFrustum view_frustum; // TODO: Definitely should go in the renderer.
 
-} render_settings_t;
+} RenderSettings;
 
-inline void update_projection_m4(render_settings_t* rs, float aspect_ratio)
+inline void update_projection_m4(RenderSettings* rs, float aspect_ratio)
 {
 	// TODO: Get rid of this helper function.
 	m4_projection(rs->fov, aspect_ratio, rs->near_plane, rs->far_plane, rs->projection_matrix);

--- a/engine/engine/renderer/render_target.h
+++ b/engine/engine/renderer/render_target.h
@@ -13,23 +13,23 @@
 // Contains the different buffers needed for rendering.
 typedef struct
 {
-	canvas_t canvas;
+	Canvas canvas;
 	float* depth_buffer;
 
-} render_target_t;
+} RenderTarget;
 
 // TODO: .c file?
-inline status_t render_target_init(render_target_t* rt, const int width, const int height)
+inline Status render_target_init(RenderTarget* rt, const int width, const int height)
 {
-    memset(rt, 0, sizeof(render_target_t));
+    memset(rt, 0, sizeof(RenderTarget));
 
-    status_t status = canvas_init(&rt->canvas, width, height);
+    Status status = canvas_init(&rt->canvas, width, height);
     if (STATUS_OK != status)
     {
         return status;
     }
 
-    // TODO: Refactor to be a depth_buffer_t.
+    // TODO: Refactor to be a DepthBuffer.
     rt->depth_buffer = malloc((size_t)width * height * sizeof(float));
 
     if (!rt->depth_buffer)
@@ -41,9 +41,9 @@ inline status_t render_target_init(render_target_t* rt, const int width, const i
     return STATUS_OK;
 }
 
-inline status_t render_target_resize(render_target_t* rt, int width, int height)
+inline Status render_target_resize(RenderTarget* rt, int width, int height)
 {
-    status_t status = canvas_resize(&rt->canvas, width, height);
+    Status status = canvas_resize(&rt->canvas, width, height);
 
     if (STATUS_OK != status)
     {
@@ -67,7 +67,7 @@ inline status_t render_target_resize(render_target_t* rt, int width, int height)
     return STATUS_OK;
 }
 
-inline void render_target_clear(render_target_t* rt, uint32_t bg_colour)
+inline void render_target_clear(RenderTarget* rt, uint32_t bg_colour)
 {
     const int length = rt->canvas.width * rt->canvas.height;
 
@@ -89,7 +89,7 @@ inline void render_target_clear(render_target_t* rt, uint32_t bg_colour)
 }
 
 
-inline void render_target_destroy(render_target_t* rt)
+inline void render_target_destroy(RenderTarget* rt)
 {
     canvas_destroy(&rt->canvas);
 

--- a/engine/engine/renderer/renderer.c
+++ b/engine/engine/renderer/renderer.c
@@ -1,16 +1,16 @@
 #include "renderer.h"
 
-status_t renderer_init(renderer_t* renderer, int width, int height)
+Status renderer_init(Renderer* renderer, int width, int height)
 {
 	// Initialise the render target.
-	status_t status = render_target_init(&renderer->target, width, height);
+	Status status = render_target_init(&renderer->target, width, height);
 	if (STATUS_OK != status)
 	{
 		return status;
 	}
 
 	// Initialise the render settings.
-	memset(&renderer->settings, 0, sizeof(render_settings_t));
+	memset(&renderer->settings, 0, sizeof(RenderSettings));
 
 	renderer->settings.fov = 90.f;
 	renderer->settings.near_plane = 1.f;
@@ -19,7 +19,7 @@ status_t renderer_init(renderer_t* renderer, int width, int height)
 	update_projection_m4(&renderer->settings, width / (float)height);
 
 	// Create a camera.
-	memset(&renderer->camera, 0, sizeof(camera_t));
+	memset(&renderer->camera, 0, sizeof(Camera));
 	renderer->camera.direction.x = 0;
 	renderer->camera.direction.y = 0;
 	renderer->camera.direction.z = -1.f;
@@ -37,10 +37,10 @@ status_t renderer_init(renderer_t* renderer, int width, int height)
 	return STATUS_OK;
 }
 
-status_t renderer_resize(renderer_t* renderer, int width, int height)
+Status renderer_resize(Renderer* renderer, int width, int height)
 {
 	// Resize the render target.
-	status_t status = render_target_resize(&renderer->target, width, height);
+	Status status = render_target_resize(&renderer->target, width, height);
 	if (STATUS_OK != status)
 	{
 		return status;

--- a/engine/engine/renderer/renderer.h
+++ b/engine/engine/renderer/renderer.h
@@ -10,16 +10,16 @@
 
 typedef struct
 {
-	render_target_t target;
-	render_settings_t settings;
-	camera_t camera;
+	RenderTarget target;
+	RenderSettings settings;
+	Camera camera;
 
 
-	frame_data_t frame_data;
+	FrameData frame_data;
 	
-} renderer_t;
+} Renderer;
 
-status_t renderer_init(renderer_t* renderer, int width, int height);
-status_t renderer_resize(renderer_t* renderer, int width, int height);
+Status renderer_init(Renderer* renderer, int width, int height);
+Status renderer_resize(Renderer* renderer, int width, int height);
 
 #endif

--- a/engine/engine/renderer/texture.c
+++ b/engine/engine/renderer/texture.c
@@ -5,13 +5,13 @@
 
 #include <Windows.h>
 
-status_t texture_load_from_bmp(texture_t* texture, const char* file)
+Status texture_load_from_bmp(Texture* texture, const char* file)
 {
     // TODO: Do we need to use Windows.h here? If we're only loading
     //       bitmaps, the image loading code could be quite simple.
 
     // Initialise the texture.
-    memset(texture, 0, sizeof(texture_t));
+    memset(texture, 0, sizeof(Texture));
 
     // Try load the bitmap.
     HBITMAP h_bitmap = (HBITMAP)LoadImageA(
@@ -106,7 +106,7 @@ status_t texture_load_from_bmp(texture_t* texture, const char* file)
     return STATUS_OK;
 }
 
-void texture_destroy(texture_t* texture)
+void texture_destroy(Texture* texture)
 {
     chds_vec_destroy(texture->pixels);
 

--- a/engine/engine/renderer/texture.h
+++ b/engine/engine/renderer/texture.h
@@ -9,15 +9,15 @@
 
 // TODO: Refactor to simply be a canvas?? (e.g. remove texture?)
 typedef struct {
-	//float* data; // TODO: Should texture be uint32_t like canvas_t again? And we can still access each component?
+	//float* data; // TODO: Should texture be uint32_t like Canvas again? And we can still access each component?
     CHDS_VEC(float) pixels;
 	int width;
 	int height;
 
-} texture_t;
+} Texture;
 
-status_t texture_load_from_bmp(texture_t* texture, const char* file);
+Status texture_load_from_bmp(Texture* texture, const char* file);
 
-void texture_destroy(texture_t* texture);
+void texture_destroy(Texture* texture);
 
 #endif

--- a/engine/engine/scripts/gameplay/player_controller.h
+++ b/engine/engine/scripts/gameplay/player_controller.h
@@ -8,7 +8,7 @@
 // TODO: Refactor this script to really make sense, e.g. we can pass in a camera offset.
 uint8_t third_person = 1;
 
-inline void player_controller_physics(engine_t* engine, cecs_entity_id eid, float dt)
+inline void player_controller_physics(Engine* engine, cecs_entity_id eid, float dt)
 {
     if (engine->input_mode != INPUT_MODE_GAME) return;
 
@@ -29,12 +29,12 @@ inline void player_controller_physics(engine_t* engine, cecs_entity_id eid, floa
     
     */
 
-    const static v3_t up = { 0, 1.f, 0 };
-    const v3_t forward = v3_normalised((v3_t) { engine->renderer.camera.direction.x, 0.f, engine->renderer.camera.direction.z });
-    const v3_t right = v3_normalised(cross(forward, up));
+    const static V3 up = { 0, 1.f, 0 };
+    const V3 forward = v3_normalised((V3) { engine->renderer.camera.direction.x, 0.f, engine->renderer.camera.direction.z });
+    const V3 right = v3_normalised(cross(forward, up));
 
-    physics_data_t* pd = cecs_get_component(engine->ecs, eid, COMPONENT_PHYSICS_DATA);
-    transform_t* t = cecs_get_component(engine->ecs, eid, COMPONENT_TRANSFORM);
+    PhysicsData* pd = cecs_get_component(engine->ecs, eid, COMPONENT_PHYSICS_DATA);
+    Transform* t = cecs_get_component(engine->ecs, eid, COMPONENT_TRANSFORM);
 
     // By multiplying by dt we're essentially converting the force into an impulse.
     const float speed = 20.f * dt * pd->mass;
@@ -63,24 +63,24 @@ inline void player_controller_physics(engine_t* engine, cecs_entity_id eid, floa
     }    
 }
 
-inline void player_controller_camera(engine_t* engine, cecs_entity_id eid)
+inline void player_controller_camera(Engine* engine, cecs_entity_id eid)
 {
     if (engine->input_mode != INPUT_MODE_GAME) return;
 
-    transform_t* t = cecs_get_component(engine->ecs, eid, COMPONENT_TRANSFORM);
+    Transform* t = cecs_get_component(engine->ecs, eid, COMPONENT_TRANSFORM);
 
-    const static v3_t up = { 0, 1.f, 0 };
-    const v3_t forward = v3_normalised((v3_t) { engine->renderer.camera.direction.x, 0.f, engine->renderer.camera.direction.z });
-    const v3_t right = v3_normalised(cross(forward, up));
+    const static V3 up = { 0, 1.f, 0 };
+    const V3 forward = v3_normalised((V3) { engine->renderer.camera.direction.x, 0.f, engine->renderer.camera.direction.z });
+    const V3 right = v3_normalised(cross(forward, up));
 
-    v3_t player_pos = v3_lerp(t->previous_position, t->position, engine->renderer.frame_data.physics_alpha);
+    V3 player_pos = v3_lerp(t->previous_position, t->position, engine->renderer.frame_data.physics_alpha);
     if (third_person)
     {
         const static float cam_dist = 4.f;
         const static float lateral_offset = 2.f;
         const static float vertical_offset = 2.f;
 
-        v3_t pos = v3_sub_v3(player_pos, v3_mul_f(engine->renderer.camera.direction, cam_dist));
+        V3 pos = v3_sub_v3(player_pos, v3_mul_f(engine->renderer.camera.direction, cam_dist));
         v3_add_eq_v3(&pos, v3_mul_f(right, lateral_offset));
         v3_add_eq_v3(&pos, v3_mul_f(up, vertical_offset));
         engine->renderer.camera.position = pos;

--- a/engine/engine/scripts/rendering/billboard.h
+++ b/engine/engine/scripts/rendering/billboard.h
@@ -3,16 +3,16 @@
 
 #include <core/engine.h>
 
-inline void update_billboard(engine_t* engine, cecs_entity_id eid, float dt)
+inline void update_billboard(Engine* engine, cecs_entity_id eid, float dt)
 {
     // TODO: Should be a billboard tag component which you add to an entity, then a system does this for you.
     // TODO: Could be an engine functon to create a billboard entity.
     // TODO: We really want to support transparency in textures for this.
 
 
-    transform_t* transform = cecs_add_component(engine->ecs, eid, COMPONENT_TRANSFORM);
+    Transform* transform = cecs_add_component(engine->ecs, eid, COMPONENT_TRANSFORM);
 
-    v3_t dir = v3_sub_v3(transform->position, engine->renderer.camera.position);
+    V3 dir = v3_sub_v3(transform->position, engine->renderer.camera.position);
     v3_normalise(&dir);
 
     direction_to_eulers(dir, &transform->rotation.x, &transform->rotation.y);

--- a/engine/engine/ui/font.c
+++ b/engine/engine/ui/font.c
@@ -4,7 +4,7 @@
 
 #include <Windows.h>
 
-static int get_char_index(const font_t* font, char c)
+static int get_char_index(const Font* font, char c)
 {
     // TODO: Switch to a map of precalculated offsets possibly?
     int defined = 0;
@@ -28,11 +28,11 @@ static int get_char_index(const font_t* font, char c)
     return char_index;
 }
 
-static int get_initial_atlas_char_offset(const font_t* font, 
+static int get_initial_atlas_char_offset(const Font* font, 
     const int initial_atlas_width, char c)
 {
     // Returns the offset to the char in the given font atlas, therefore,
-    // requires the initial atlas width.
+    // reqUIres the initial atlas width.
 
     int char_index = get_char_index(font, c);
     if (-1 == char_index) return -1;
@@ -50,13 +50,13 @@ static int get_initial_atlas_char_offset(const font_t* font,
     return rowOffset + colOffset;
 }
 
-status_t font_init(font_t* font)
+Status font_init(Font* font)
 {
     // TODO: There are strict rules about the input axis, should write these
     //       out properly!!! pixel gap between rows/cols etc
     
     // Initialise the font struct.
-	memset(font, 0, sizeof(font_t));
+	memset(font, 0, sizeof(Font));
 
 	// Initialise the character data.
     // TODO: Allow this to be set?
@@ -66,9 +66,9 @@ status_t font_init(font_t* font)
 	font->char_height = 9;
 
     // Read the given font atlas.
-    canvas_t src;
+    Canvas src;
     // TODO: Stop hardcoding this path.
-    status_t status = canvas_init_from_bitmap(&src, "C:/Users/olive/source/repos/csrge/res/fonts/minogram_6x10_font.bmp");
+    Status status = canvas_init_from_bitmap(&src, "C:/Users/olive/source/repos/csrge/res/fonts/minogram_6x10_font.bmp");
     if (STATUS_OK != status)
     {
         log_error("Failed to load font atlas bitmap, status: %s", status_to_str(status));
@@ -111,7 +111,7 @@ status_t font_init(font_t* font)
 	return STATUS_OK;
 }
 
-int font_get_char_offset(font_t* font, char c)
+int font_get_char_offset(Font* font, char c)
 {
     // TODO: Switch to a map of precalculated offsets possibly?
     int char_index = get_char_index(font, c);

--- a/engine/engine/ui/font.h
+++ b/engine/engine/ui/font.h
@@ -12,12 +12,12 @@ typedef struct
 
 	const char* defined_chars;
 
-    canvas_t atlas;
+    Canvas atlas;
 
-} font_t;
+} Font;
 
-status_t font_init(font_t* font);
+Status font_init(Font* font);
 
-int font_get_char_offset(font_t* font, char c);
+int font_get_char_offset(Font* font, char c);
 
 #endif

--- a/engine/engine/ui/text.c
+++ b/engine/engine/ui/text.c
@@ -4,10 +4,10 @@
 
 #include <math.h>
 
-text_t text_create(char* str, int x, int y, int colour, int scale)
+Text text_create(char* str, int x, int y, int colour, int scale)
 {
 	// TODO: text_init instead and modify pointer?
-	text_t text = {
+	Text text = {
 		.text = str,
 		.x = x,
 		.y = y,
@@ -18,10 +18,10 @@ text_t text_create(char* str, int x, int y, int colour, int scale)
 	return text;
 }
 
-void text_draw(canvas_t* canvas, text_t* text, font_t* font, float upscaling_factor)
+void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor)
 {
-	// TODO: All ui should be scaled the same so we can at least keep 
-	// consistency with the ui.
+	// TODO: All UI should be scaled the same so we can at least keep 
+	// consistency with the UI.
 	// TODO: I want the text to stay as similar as possible when upscaling.
 	
 	int scale = (int)fmaxf(text->scale / upscaling_factor, 1.f);

--- a/engine/engine/ui/text.h
+++ b/engine/engine/ui/text.h
@@ -12,10 +12,10 @@ typedef struct
 	int colour;
 	int scale;
 
-} text_t;
+} Text;
 
-text_t text_create(char* text, int x, int y, int colour, int scale);
+Text text_create(char* text, int x, int y, int colour, int scale);
 
-void text_draw(canvas_t* canvas, text_t* text, font_t* font, float upscaling_factor);
+void text_draw(Canvas* canvas, Text* text, Font* font, float upscaling_factor);
 
 #endif

--- a/engine/engine/ui/ui.c
+++ b/engine/engine/ui/ui.c
@@ -1,28 +1,28 @@
-#include "ui.h"
+#include "UI.h"
 
-status_t ui_init(ui_t* ui, canvas_t* canvas)
+Status UI_init(UI* UI, Canvas* canvas)
 {
-	status_t status = font_init(&ui->font);
+	Status status = font_init(&UI->font);
 	if (STATUS_OK != status)
 	{
 		return status;
 	}
 
-	ui->canvas = canvas;
+	UI->canvas = canvas;
 
 	return STATUS_OK;
 }
 
-void ui_draw(ui_t* ui, float upscaling_factor)
+void UI_draw(UI* UI, float upscaling_factor)
 {
-	for (int i = 0; i < ui->text_count; ++i)
+	for (int i = 0; i < UI->text_count; ++i)
 	{
-		// TODO: text_t needs to be scaled. Or how do I do it not scaled.
-		text_draw(ui->canvas, &ui->text[i], &ui->font, upscaling_factor);
+		// TODO: Text needs to be scaled. Or how do I do it not scaled.
+		text_draw(UI->canvas, &UI->text[i], &UI->font, upscaling_factor);
 	}
 }
 
-void ui_destroy(ui_t* ui)
+void UI_destroy(UI* UI)
 {
 
 }

--- a/engine/engine/ui/ui.h
+++ b/engine/engine/ui/ui.h
@@ -14,22 +14,22 @@
 
 typedef struct
 {
-	// Global ui_t
-	canvas_t* canvas;
-	font_t font;
+	// Global UI
+	Canvas* canvas;
+	Font font;
 
 	// Specific widgets
 	int text_count;
-	text_t text[MAX_TEXT];
+	Text text[MAX_TEXT];
 
-} ui_t;
+} UI;
 
-status_t ui_init(ui_t* ui, canvas_t* canvas);
+Status UI_init(UI* UI, Canvas* canvas);
 
-void ui_draw(ui_t* ui, float upscaling_factor);
+void UI_draw(UI* UI, float upscaling_factor);
 
-void ui_destroy(ui_t* ui);
+void UI_destroy(UI* UI);
 
-// Functions for adding ui_t widgets?
+// Functions for adding UI widgets?
 
 #endif

--- a/engine/engine/utils/timer.h
+++ b/engine/engine/utils/timer.h
@@ -9,11 +9,11 @@ typedef struct
 {
 	clock_t start;
 
-} timer_t;
+} Timer;
 
-inline timer_t timer_start()
+inline Timer timer_start()
 {
-	timer_t timer =
+	Timer timer =
 	{
 		.start = clock()
 	};
@@ -21,12 +21,12 @@ inline timer_t timer_start()
 	return timer;
 }
 
-inline int timer_get_elapsed(timer_t* timer)
+inline int timer_get_elapsed(Timer* timer)
 {
 	return (int)((clock() - timer->start) * 1000 / CLOCKS_PER_SEC);
 }
 
-inline void timer_restart(timer_t* timer)
+inline void timer_restart(Timer* timer)
 {
 	timer->start = clock();
 }

--- a/game/main.c
+++ b/game/main.c
@@ -14,19 +14,19 @@
 
 float* directions;
 
-mesh_base_id_t sphere_base;
-mesh_base_id_t cube_base;
-mesh_base_id_t map_base;
-mesh_base_id_t monkey_base;
-mesh_base_id_t bowl_base;
-mesh_base_id_t terrain_base;
+MeshBaseId sphere_base;
+MeshBaseId cube_base;
+MeshBaseId map_base;
+MeshBaseId monkey_base;
+MeshBaseId bowl_base;
+MeshBaseId terrain_base;
 
 cecs_entity_id map_entity;
 cecs_entity_id monkey_entity;
 cecs_entity_id player_entity;
 cecs_entity_id billboard_entity;
 
-void create_map(engine_t* engine)
+void create_map(Engine* engine)
 {
     resources_load_texture(&engine->resources, "C:/Users/olive/source/repos/csrge/res/textures/landscape.bmp");
     resources_load_texture(&engine->resources, "C:/Users/olive/source/repos/csrge/res/textures/fortnite_peter.bmp");
@@ -36,8 +36,8 @@ void create_map(engine_t* engine)
     
     // TODO: Also for models, the scene could be global? I think MBs should be 
     //       global?
-    scene_t* scene = &engine->scene;
-    status_t status = scene_init(scene);
+    Scene* scene = &engine->scene;
+    Status status = scene_init(scene);
     
     // Load some mesh bases.
     sphere_base = mesh_bases_add(&scene->mesh_bases);
@@ -63,29 +63,29 @@ void create_map(engine_t* engine)
         cecs_entity_id cube_entity = cecs_create_entity(engine->ecs);
         map_entity = cube_entity;
 
-        // Add a mesh_instance_t component.
-        mesh_instance_t* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
+        // Add a MeshInstance component.
+        MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &scene->mesh_bases.bases[terrain_base]);
 
         mi->texture_id = 0;
 
         {
-            transform_t* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
+            Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
             transform_init(transform);
             transform->scale = v3_uniform(10);
         }
         
         // TODO: currently testing with static.
-        //physics_data_t* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+        //PhysicsData* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
         //physics_data_init(physics_data);
-        //physics_data->force = (v3_t){ 0,0,1 };
+        //physics_data->force = (V3){ 0,0,1 };
 
-        collider_t* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
+        Collider* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
         collider_init(collider);
 
         collider->shape.type = COLLISION_SHAPE_MESH;
 
-        //physics_data_t* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+        //PhysicsData* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
         //physics_data_init(pd);
         //pd->mass = 0.f; // TODO: TEMP: Isn't moved by other things?
         //pd->floating = 1;
@@ -95,26 +95,26 @@ void create_map(engine_t* engine)
     {
         player_entity = cecs_create_entity(engine->ecs);
 
-        // Add a mesh_instance_t component.
-        mesh_instance_t* mi = cecs_add_component(engine->ecs, player_entity, COMPONENT_MESH_INSTANCE);
+        // Add a MeshInstance component.
+        MeshInstance* mi = cecs_add_component(engine->ecs, player_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &scene->mesh_bases.bases[sphere_base]);
 
         mi->texture_id = 1;
 
         {
-            transform_t* transform = cecs_add_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
+            Transform* transform = cecs_add_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
             transform_init(transform);
-            transform->scale = (v3_t) { 1, 2, 1 };
-            transform->position = (v3_t) { 0, 3, 0 };
+            transform->scale = (V3) { 1, 2, 1 };
+            transform->position = (V3) { 0, 3, 0 };
         }
 
-        collider_t* collider = cecs_add_component(engine->ecs, player_entity, COMPONENT_COLLIDER);
+        Collider* collider = cecs_add_component(engine->ecs, player_entity, COMPONENT_COLLIDER);
         collider_init(collider);
 
         collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
-        collider->shape.ellipsoid = (v3_t){ 1,2,1 };
+        collider->shape.ellipsoid = (V3){ 1,2,1 };
 
-        physics_data_t* pd = cecs_add_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
+        PhysicsData* pd = cecs_add_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
         physics_data_init(pd);
         pd->mass = 50.f;
     }
@@ -123,30 +123,30 @@ void create_map(engine_t* engine)
     {
         billboard_entity = cecs_create_entity(engine->ecs);
 
-        // Add a mesh_instance_t component.
-        mesh_instance_t* mi = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_MESH_INSTANCE);
+        // Add a MeshInstance component.
+        MeshInstance* mi = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &scene->mesh_bases.bases[cube_base]);
 
         mi->texture_id = 2;
 
         {
-            transform_t* transform = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_TRANSFORM);
+            Transform* transform = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_TRANSFORM);
             transform_init(transform);
-            transform->scale = (v3_t){ 1, 2, 0 };
-            transform->position = (v3_t){ 5, 3, 0 };
+            transform->scale = (V3){ 1, 2, 0 };
+            transform->position = (V3){ 5, 3, 0 };
         }
 
        
-        collider_t* collider = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_COLLIDER);
+        Collider* collider = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_COLLIDER);
         collider_init(collider);
 
         //collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
-        //collider->shape.ellipsoid = (v3_t){ 1,2,1 };
+        //collider->shape.ellipsoid = (V3){ 1,2,1 };
 
         collider->shape.type = COLLISION_SHAPE_MESH;
 
         /*
-        physics_data_t* pd = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_PHYSICS_DATA);
+        PhysicsData* pd = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_PHYSICS_DATA);
         physics_data_init(pd);
         pd->mass = 50.f;*/
     }
@@ -157,28 +157,28 @@ void create_map(engine_t* engine)
         cecs_entity_id cube_entity = cecs_create_entity(engine->ecs);
         monkey_entity = cube_entity;
 
-        // Add a mesh_instance_t component.
-        mesh_instance_t* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
+        // Add a MeshInstance component.
+        MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &scene->mesh_bases.bases[monkey_base]);
 
         mi->texture_id = 0;
 
-        transform_t* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
+        Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
         transform_init(transform);
         transform->scale = v3_uniform(1);
 
         // TODO: currently testing with static.
-        //physics_data_t* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+        //PhysicsData* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
         //physics_data_init(physics_data);
-        //physics_data->force = (v3_t){ 0,0,1 };
+        //physics_data->force = (V3){ 0,0,1 };
 
-        collider_t* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
+        Collider* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
         collider_init(collider);
 
         collider->shape.type = COLLISION_SHAPE_MESH;
         //collider->shape.ellipsoid = v3_uniform(1.f);
 
-        physics_data_t* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+        PhysicsData* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
         physics_data_init(pd);
     }*/
   
@@ -188,7 +188,7 @@ void create_map(engine_t* engine)
     //             broad phase which is using the sphere.
     // Normally to calculate bounding sphere of square we would half the scale, however,
     // the input .obj goes from -1 to 1, so the length is 2.
-    v3_t half_sqrd = v3_mul_v3(transform->scale, transform->scale);
+    V3 half_sqrd = v3_mul_v3(transform->scale, transform->scale);
     float radius = sqrtf(half_sqrd.x + half_sqrd.y + half_sqrd.z);
     collider->shape.ellipsoid = v3_uniform(radius);
     printf("%f\n", radius);
@@ -199,10 +199,10 @@ void create_map(engine_t* engine)
     scene->bg_colour = 0x11111111;
     
     // TODO: Should the camera be part of the scene??
-    engine->renderer.camera.position = (v3_t) { 0, 0, 10.f };
+    engine->renderer.camera.position = (V3) { 0, 0, 10.f };
 }
 
-void engine_on_init(engine_t* engine)
+void engine_on_init(Engine* engine)
 {
     // TODO: Should really be init by the engine!!!
     g_draw_normals = 0;
@@ -212,18 +212,18 @@ void engine_on_init(engine_t* engine)
     create_map(engine);
 }
 
-void engine_before_physics(engine_t* engine, float dt)
+void engine_before_physics(Engine* engine, float dt)
 {
     {
-        physics_data_t* pd = cecs_get_component(engine->ecs, map_entity, COMPONENT_PHYSICS_DATA);
-        //pd->velocity = (v3_t){ 0.f, 0.f, -1.f };
+        PhysicsData* pd = cecs_get_component(engine->ecs, map_entity, COMPONENT_PHYSICS_DATA);
+        //pd->velocity = (V3){ 0.f, 0.f, -1.f };
     }
 
     {
-        physics_data_t* pd = cecs_get_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
-        transform_t* t = cecs_get_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
+        PhysicsData* pd = cecs_get_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
+        Transform* t = cecs_get_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
 
-        v3_t dir = v3_normalised(v3_sub_v3(engine->renderer.camera.position, t->position));
+        V3 dir = v3_normalised(v3_sub_v3(engine->renderer.camera.position, t->position));
         
         //v3_add_eq_v3(&pd->impulses, v3_mul_f(dir, 0.01));
 
@@ -233,24 +233,24 @@ void engine_before_physics(engine_t* engine, float dt)
     update_billboard(engine, billboard_entity, dt);
 }
 
-void engine_after_physics(engine_t* engine, float physics_alpha)
+void engine_after_physics(Engine* engine, float physics_alpha)
 {
     player_controller_camera(engine, player_entity);
 }
 
-void engine_on_keyup(engine_t* engine, WPARAM wParam)
+void engine_on_keyup(Engine* engine, WPARAM wParam)
 {
     switch (wParam)
     {
     case VK_F1:
     {
-        mesh_base_id_t mb_ids[2] = { cube_base, sphere_base };
+        MeshBaseId mb_ids[2] = { cube_base, sphere_base };
 
-        mesh_base_id_t mb_id = mb_ids[(int)(random_float() + 0.5f)];
+        MeshBaseId mb_id = mb_ids[(int)(random_float() + 0.5f)];
 
-        scene_t* scene = &engine->scene;
+        Scene* scene = &engine->scene;
 
-        v3_t colour =
+        V3 colour =
         {
             random_float(),
             random_float(),
@@ -258,16 +258,16 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
         };
 
         
-        const camera_t* camera = &engine->renderer.camera;
+        const Camera* camera = &engine->renderer.camera;
 
-        const v3_t pos = v3_add_v3(camera->position, v3_mul_f(camera->direction, 10.f * (random_float() + 1)));
+        const V3 pos = v3_add_v3(camera->position, v3_mul_f(camera->direction, 10.f * (random_float() + 1)));
 
         cecs_entity_id cube_entity = cecs_create_entity(engine->ecs);
-        mesh_instance_t* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
+        MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &scene->mesh_bases.bases[sphere_base]);
         mesh_instance_set_albedo(mi, &scene->mesh_bases.bases[sphere_base], colour);
 
-        transform_t* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
+        Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
         transform_init(transform);
         transform->position = pos;
 
@@ -276,13 +276,13 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
     case VK_F2:
     {
         //g_draw_normals = !g_draw_normals;
-        scene_t* scene = &engine->scene;
+        Scene* scene = &engine->scene;
         
         break;
     }
     case VK_F3:
     {
-        v3_t colour =
+        V3 colour =
         {
             random_float(),
             random_float(),
@@ -291,12 +291,12 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
         
         // TODO: Should camera be an entity component or entity or leave it? Not sure.
         //       Fine for now.
-        camera_t* camera = &engine->renderer.camera;
+        Camera* camera = &engine->renderer.camera;
         
-        const v3_t pos = v3_add_v3(camera->position, v3_mul_f(camera->direction, 10.f * (random_float() + 1)));
+        const V3 pos = v3_add_v3(camera->position, v3_mul_f(camera->direction, 10.f * (random_float() + 1)));
 
         cecs_entity_id e = cecs_create_entity(engine->ecs);
-        point_light_t* pl = cecs_add_component(engine->ecs, e, COMPONENT_POINT_LIGHT);
+        PointLight* pl = cecs_add_component(engine->ecs, e, COMPONENT_POINT_LIGHT);
         pl->position = pos;
         pl->colour = colour;
         pl->strength = 1.f;
@@ -305,7 +305,7 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
     }
     case VK_F4:
     {
-        mesh_instance_t* mi = cecs_get_component(engine->ecs, 0, COMPONENT_MESH_INSTANCE);
+        MeshInstance* mi = cecs_get_component(engine->ecs, 0, COMPONENT_MESH_INSTANCE);
         mesh_instance_destroy(mi);
         cecs_remove_component(engine->ecs, 0, COMPONENT_MESH_INSTANCE);
 
@@ -328,23 +328,23 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
         cecs_entity_id cube_entity = cecs_create_entity(engine->ecs);
         map_entity = cube_entity;
 
-        // Add a mesh_instance_t component.
-        mesh_instance_t* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
+        // Add a MeshInstance component.
+        MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &engine->scene.mesh_bases.bases[sphere_base]);
 
-        transform_t* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
+        Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
         transform_init(transform);
         transform->scale = v3_uniform(3);
-        transform->position = (v3_t){ 0, 10, 0 };
+        transform->position = (V3){ 0, 10, 0 };
 
-        collider_t* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
+        Collider* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
         collider_init(collider);
 
         collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
         collider->shape.ellipsoid = transform->scale;
 
 
-        physics_data_t* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+        PhysicsData* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
         physics_data_init(pd);
         pd->mass = 100.f;
 
@@ -357,11 +357,11 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
             cecs_entity_id cube_entity = cecs_create_entity(engine->ecs);
             map_entity = cube_entity;
 
-            // Add a mesh_instance_t component.
-            mesh_instance_t* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
+            // Add a MeshInstance component.
+            MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
             mesh_instance_init(mi, &engine->scene.mesh_bases.bases[sphere_base]);
 
-            v3_t colour =
+            V3 colour =
             {
                 random_float(),
                 random_float(),
@@ -372,18 +372,18 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
 
             mesh_instance_set_albedo(mi, &engine->scene.mesh_bases.bases[sphere_base], colour);
 
-            transform_t* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
+            Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
             transform_init(transform);
             transform->scale = v3_uniform(size);
-            transform->position = (v3_t) { 0, transform->scale.x + i * (transform->scale.x * 2), 0 };
+            transform->position = (V3) { 0, transform->scale.x + i * (transform->scale.x * 2), 0 };
 
-            collider_t* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
+            Collider* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
             collider_init(collider);
 
             collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
             collider->shape.ellipsoid = transform->scale;
 
-            physics_data_t* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+            PhysicsData* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
             physics_data_init(pd);
             pd->mass = 1.f;
         }
@@ -399,24 +399,24 @@ void engine_on_keyup(engine_t* engine, WPARAM wParam)
     }
 }
 
-void engine_on_lmbdown(engine_t* engine)
+void engine_on_lmbdown(Engine* engine)
 {
-    scene_t* scene = &engine->scene;
+    Scene* scene = &engine->scene;
 
     // Create an entity
     cecs_entity_id cube_entity = cecs_create_entity(engine->ecs);
 
-    //mesh_base_t* mb = &scene->mesh_bases.bases[cube_base];
-    mesh_base_t* mb = &scene->mesh_bases.bases[sphere_base];
+    //MeshBase* mb = &scene->mesh_bases.bases[cube_base];
+    MeshBase* mb = &scene->mesh_bases.bases[sphere_base];
 
-    // Add a mesh_instance_t component.
+    // Add a MeshInstance component.
     cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
-    mesh_instance_t* mi = cecs_get_component(engine->ecs, cube_entity,
+    MeshInstance* mi = cecs_get_component(engine->ecs, cube_entity,
         COMPONENT_MESH_INSTANCE);
     mesh_instance_init(mi, mb);
 
 
-    v3_t colour =
+    V3 colour =
     {
         random_float(),
         random_float(),
@@ -426,16 +426,16 @@ void engine_on_lmbdown(engine_t* engine)
 
     cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
 
-    transform_t* transform = cecs_get_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
+    Transform* transform = cecs_get_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
     transform_init(transform);
     transform->position = v3_add_v3(engine->renderer.camera.position, v3_mul_f(engine->renderer.camera.direction, 3));
     transform->scale = v3_uniform(0.1f);
 
 
     //transform->scale = v3_uniform(0.1);
-    //transform->scale = (v3_t){ 0.5f,2,1 };
+    //transform->scale = (V3){ 0.5f,2,1 };
 
-    physics_data_t* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
+    PhysicsData* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
     physics_data_init(physics_data);
 
     physics_data->mass = 1.f;
@@ -444,16 +444,16 @@ void engine_on_lmbdown(engine_t* engine)
     float speed = physics_data->mass * 20.f;
     v3_add_eq_v3(&physics_data->impulses, v3_mul_f(engine->renderer.camera.direction, speed));
 
-    // TODO: Must remember that the pointers go invalid quick, should specifiy this in cecs!!!!
+    // TODO: Must remember that the pointers go invalid qUIck, should specifiy this in cecs!!!!
 
-    collider_t* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
+    Collider* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
     collider_init(collider);
     collider->shape.ellipsoid = transform->scale;
 }
 
 int main()
 {
-	engine_t engine;
+	Engine engine;
 	if (STATUS_OK == engine_init(&engine, 800, 600))
 	{
 		engine_run(&engine);


### PR DESCRIPTION
Note, this is different to the used libs CHDS and CECS, however, I believe this is cleaner and might also update those. This is currently necessary because the engine structs do not have a lib prefix, therefore, naming the type e.g. engine would clash with vars named engine, therefore, Engine is nicer.

Also, I quite like the SDL naming conventions e.g. SDL_Renderer for the type and SDL_RendererInit for the func, may opt for this down the line.