### PR TITLE
fix(collision): ellipsoid/mi calculation of world space penetration depth and collision normal

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,9 +7,10 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "installDir": "${sourceDir}/out/install/${presetName}",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl.exe"
-            },
+          "cacheVariables": {
+            "CMAKE_C_COMPILER": "cl.exe",
+            "CMAKE_PREFIX_PATH": "engine\\libs"
+          },
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",

--- a/engine/engine/core/engine.c
+++ b/engine/engine/core/engine.c
@@ -218,10 +218,13 @@ void engine_run(Engine* engine)
 
         snprintf(physics_str, sizeof(physics_str), "Physics: %d", timer_get_elapsed(&t));
 
-        // Calculate how far we are through 
+        // Calculate how far we are through the next physics frame?
+        // TODO: how is this right though if the physics system hasn't consumed the movement
+        //       for the remaining dt then why would we use this for the camera?
         engine->renderer.frame_data.physics_alpha = physics_dt_counter / physics_dt;
 
         // Call after physics, e.g. update camera smoothly using physics alpha.
+        // TODO: i don't quite get this anymore, comments should actually explain why not what.
         engine_after_physics(engine, engine->renderer.frame_data.physics_alpha);
         
         // Clear the canvas.

--- a/engine/engine/physics/collision.c
+++ b/engine/engine/physics/collision.c
@@ -494,7 +494,8 @@ static void unit_sphere_tri_vertex_collision(V3 p, V3 centre, uint8_t* collided,
     float d = v3_size(v3_sub_v3(p, centre));
 
     // Choose the point of furthest collision, this should ensure we 
-    // push the ellipsoid fully out of the triangle!
+    // push the ellipsoid fully out of the triangle! Note, this does
+    // not necessarily mean the first collision.
     if (d < 1.f)
     {
         // Only return a collision if the distance is greater than the
@@ -602,25 +603,29 @@ static void narrow_ellipsoid_vs_mi(Physics* physics, Scene* scene, PotentialColl
 
         if (collided)
         {
-            V3 actual_plane_collision_point = v3_mul_v3(collision_point, ellipsoid);
+            V3 e_collision_normal = v3_normalised(v3_sub_v3(e_start_pos, collision_point));
 
-            V3 collision_normal = v3_sub_v3(ellipsoid_transform->position, actual_plane_collision_point);
-            v3_normalise(&collision_normal);
+            // Normals are defined as perpendicular to a surface, non-uniform scaling doesn't preserve
+            // this if transformed like a normal vector. To transform normals, we use the inverse-transpose
+            // of the scaling matrix, as the scaling is diagonal, in this case we just multiply component-wise
+            // by the inverse of the scale, i.e. divide by the scale.
 
-            V3 n = v3_add_v3(collision_point, collision_normal);
-            v3_mul_eq_v3(&n, ellipsoid);
+            // The normal points from the surface towards the ellipsoid centre as we're wanting to move out
+            // of the surface.
+            V3 w_collision_normal = v3_normalised(v3_mul_v3(e_collision_normal, inv_ellipsoid));
 
-            float dist = v3_size(v3_sub_v3(n, e_pos));
+            // Get the vector that would push the unit sphere out of the triangle and convert to world space.
+            // Note, this is not a normal hence we don't use the inverse-transpose.
+            V3 penetration_vector = v3_mul_v3(v3_mul_f(e_collision_normal, penetration_depth), ellipsoid);
 
-            // TODO: penetration depth is in ellipsoid space.
-            // TODO: TEMP sol? for uniformly scaled sphere
-            penetration_depth *= ellipsoid.x; // Using x as radius here.
-
+            // Non-uniform scaling can change the vector direction, so project the transformed penetration
+            // vector onto the world space collision normal.
+            float depth_world = dot(penetration_vector, w_collision_normal);
 
             CollisionData cd = { 0 };
-            cd.collision_normal = collision_normal;
+            cd.collision_normal = w_collision_normal;
             cd.hit = 1;
-            cd.penetration_depth = penetration_depth;
+            cd.penetration_depth = depth_world;
             cd.pc = pc;
             
             chds_vec_push(physics->frame.collisions, cd);

--- a/engine/engine/physics/collision.c
+++ b/engine/engine/physics/collision.c
@@ -464,11 +464,16 @@ static void unit_sphere_tri_edge_collision(V3 p0, V3 p1, V3 centre, uint8_t* col
     {
         V3 tmp_collision_point = v3_add_v3(p0, v3_mul_f(p1p0, t));
 
+        // TODO: TEMP: TESTING, why were we using size_sqrd? that won't give us actual distance?
+        // I think size_sqrd works for the test, but we need the actual distance for the penetration depth
         if (v3_size_sqrd(v3_sub_v3(tmp_collision_point, centre)) <= 1.f)
         {
             // Only return a collision if the distance is greater than the
             // inputted penetration depth.
-            float tmp_penetration_depth = 1.f - v3_size_sqrd(v3_sub_v3(tmp_collision_point, centre));
+
+            // TODO: also we're doing this twice?
+            float dist = v3_size(v3_sub_v3(tmp_collision_point, centre));
+            float tmp_penetration_depth = 1.f - dist;
             if (!*collided || tmp_penetration_depth > *penetration_depth)
             {
                 *collided = 1;
@@ -482,7 +487,11 @@ static void unit_sphere_tri_edge_collision(V3 p0, V3 p1, V3 centre, uint8_t* col
 static void unit_sphere_tri_vertex_collision(V3 p, V3 centre, uint8_t* collided, V3* collision_point, float* penetration_depth)
 {
     // If distance between vertex and sphere centre is less than radius, we are colliding.
-    float d = v3_size_sqrd(v3_sub_v3(p, centre));
+
+    // TODO: why were we using size_sqrd?
+    //float d = v3_size_sqrd(v3_sub_v3(p, centre));
+
+    float d = v3_size(v3_sub_v3(p, centre));
 
     // Choose the point of furthest collision, this should ensure we 
     // push the ellipsoid fully out of the triangle!
@@ -603,11 +612,17 @@ static void narrow_ellipsoid_vs_mi(Physics* physics, Scene* scene, PotentialColl
 
             float dist = v3_size(v3_sub_v3(n, e_pos));
 
+            // TODO: penetration depth is in ellipsoid space.
+            // TODO: TEMP sol? for uniformly scaled sphere
+            penetration_depth *= ellipsoid.x; // Using x as radius here.
+
+
             CollisionData cd = { 0 };
             cd.collision_normal = collision_normal;
             cd.hit = 1;
             cd.penetration_depth = penetration_depth;
             cd.pc = pc;
+            
             chds_vec_push(physics->frame.collisions, cd);
         }
     }

--- a/engine/engine/physics/physics.c
+++ b/engine/engine/physics/physics.c
@@ -182,7 +182,7 @@ void physics_data_init(PhysicsData* data)
 
 void physics_tick(Physics* physics, Scene* scene, float dt)
 {
-    // TODO: TEMP: 
+    // TODO: TEMP: updates previous position for smooth lerp.
     {
         CECS_ViewId v = cecs_view_create(physics->ecs, CECS_COMPONENT_ID_TO_BITSET(COMPONENT_TRANSFORM), 0);
         CECS_ViewIter it = cecs_view_iter_create(physics->ecs, v);

--- a/game/main.c
+++ b/game/main.c
@@ -97,10 +97,12 @@ void create_map(Engine* engine)
 
         mi->texture_id = 1;
 
+        V3 player_scale = (V3) { 1, 2, 1 };
+
         {
             Transform* transform = cecs_add_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
             transform_init(transform);
-            transform->scale = (V3) { 1, 2, 1 };
+            transform->scale = player_scale;
             transform->position = (V3) { 0, 3, 0 };
         }
 
@@ -108,7 +110,7 @@ void create_map(Engine* engine)
         collider_init(collider);
 
         collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
-        collider->shape.ellipsoid = (V3){ 1,2,1 };
+        collider->shape.ellipsoid = player_scale;
 
         PhysicsData* pd = cecs_add_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
         physics_data_init(pd);

--- a/game/main.c
+++ b/game/main.c
@@ -10,21 +10,18 @@
 #include <engine/common/status.h>
 
 #include <engine/scripts/gameplay/player_controller.h>
-#include <engine/scripts/rendering/billboard.h>
 
 float* directions;
 
 MeshBaseId sphere_base;
 MeshBaseId cube_base;
 MeshBaseId map_base;
-MeshBaseId monkey_base;
 MeshBaseId bowl_base;
 MeshBaseId terrain_base;
 
 CECS_EntityId map_entity;
-CECS_EntityId monkey_entity;
 CECS_EntityId player_entity;
-CECS_EntityId billboard_entity;
+CECS_EntityId light_entity;
 
 void create_map(Engine* engine)
 {
@@ -49,9 +46,6 @@ void create_map(Engine* engine)
     map_base = mesh_bases_add(&scene->mesh_bases);
     mesh_base_from_obj(&scene->mesh_bases.bases[map_base], "C:/Users/olive/source/repos/csrge/res/models/physics_test_map.obj");
 
-    monkey_base = mesh_bases_add(&scene->mesh_bases);
-    mesh_base_from_obj(&scene->mesh_bases.bases[monkey_base], "C:/Users/olive/source/repos/csrge/res/models/suzanne.obj");
-
     bowl_base = mesh_bases_add(&scene->mesh_bases);
     mesh_base_from_obj(&scene->mesh_bases.bases[bowl_base], "C:/Users/olive/source/repos/csrge/res/models/bowl.obj");
 
@@ -67,7 +61,7 @@ void create_map(Engine* engine)
         MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
         mesh_instance_init(mi, &scene->mesh_bases.bases[terrain_base]);
 
-        mi->texture_id = 0;
+        //mi->texture_id = 0;
 
         {
             Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
@@ -119,82 +113,16 @@ void create_map(Engine* engine)
         pd->mass = 50.f;
     }
 
-    // Create billboard
+    // Point light
     {
-        billboard_entity = cecs_create_entity(engine->ecs);
-
-        // Add a MeshInstance component.
-        MeshInstance* mi = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_MESH_INSTANCE);
-        mesh_instance_init(mi, &scene->mesh_bases.bases[cube_base]);
-
-        mi->texture_id = 2;
-
-        {
-            Transform* transform = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_TRANSFORM);
-            transform_init(transform);
-            transform->scale = (V3){ 1, 2, 0 };
-            transform->position = (V3){ 5, 3, 0 };
-        }
-
-       
-        Collider* collider = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_COLLIDER);
-        collider_init(collider);
-
-        //collider->shape.type = COLLISION_SHAPE_ELLIPSOID;
-        //collider->shape.ellipsoid = (V3){ 1,2,1 };
-
-        collider->shape.type = COLLISION_SHAPE_MESH;
-
-        /*
-        PhysicsData* pd = cecs_add_component(engine->ecs, billboard_entity, COMPONENT_PHYSICS_DATA);
-        physics_data_init(pd);
-        pd->mass = 50.f;*/
+        light_entity = cecs_create_entity(engine->ecs);
+        PointLight* pl = cecs_add_component(engine->ecs, light_entity, COMPONENT_POINT_LIGHT);
+        pl->position = (V3){ 0, 50, 1 };
+        pl->colour = v3_uniform(1.f);
+        pl->strength = 50.f;
     }
-    
-    // MONKEY
-    /*
-    {
-        CECS_EntityId cube_entity = cecs_create_entity(engine->ecs);
-        monkey_entity = cube_entity;
 
-        // Add a MeshInstance component.
-        MeshInstance* mi = cecs_add_component(engine->ecs, cube_entity, COMPONENT_MESH_INSTANCE);
-        mesh_instance_init(mi, &scene->mesh_bases.bases[monkey_base]);
-
-        mi->texture_id = 0;
-
-        Transform* transform = cecs_add_component(engine->ecs, cube_entity, COMPONENT_TRANSFORM);
-        transform_init(transform);
-        transform->scale = v3_uniform(1);
-
-        // TODO: currently testing with static.
-        //PhysicsData* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
-        //physics_data_init(physics_data);
-        //physics_data->force = (V3){ 0,0,1 };
-
-        Collider* collider = cecs_add_component(engine->ecs, cube_entity, COMPONENT_COLLIDER);
-        collider_init(collider);
-
-        collider->shape.type = COLLISION_SHAPE_MESH;
-        //collider->shape.ellipsoid = v3_uniform(1.f);
-
-        PhysicsData* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
-        physics_data_init(pd);
-    }*/
-  
-
-    /*
-    // TODO: TEMP: Currently setting the spawned cube to have an ellipsoid collider, but this is just for the 
-    //             broad phase which is using the sphere.
-    // Normally to calculate bounding sphere of square we would half the scale, however,
-    // the input .obj goes from -1 to 1, so the length is 2.
-    V3 half_sqrd = v3_mul_v3(transform->scale, transform->scale);
-    float radius = sqrtf(half_sqrd.x + half_sqrd.y + half_sqrd.z);
-    collider->shape.ellipsoid = v3_uniform(radius);
-    printf("%f\n", radius);
-    */
-    scene->ambient_light = v3_uniform(1.f);
-    //scene->ambient_light = v3_uniform(0.1f);
+    scene->ambient_light = v3_uniform(0.3f);
     
     scene->bg_colour = 0x11111111;
     
@@ -214,23 +142,7 @@ void engine_on_init(Engine* engine)
 
 void engine_before_physics(Engine* engine, float dt)
 {
-    {
-        PhysicsData* pd = cecs_get_component(engine->ecs, map_entity, COMPONENT_PHYSICS_DATA);
-        //pd->velocity = (V3){ 0.f, 0.f, -1.f };
-    }
-
-    {
-        PhysicsData* pd = cecs_get_component(engine->ecs, player_entity, COMPONENT_PHYSICS_DATA);
-        Transform* t = cecs_get_component(engine->ecs, player_entity, COMPONENT_TRANSFORM);
-
-        V3 dir = v3_normalised(v3_sub_v3(engine->renderer.camera.position, t->position));
-        
-        //v3_add_eq_v3(&pd->impulses, v3_mul_f(dir, 0.01));
-
-    }
-
     player_controller_physics(engine, player_entity, dt);
-    update_billboard(engine, billboard_entity, dt);
 }
 
 void engine_after_physics(Engine* engine, float physics_alpha)

--- a/game/main.c
+++ b/game/main.c
@@ -79,6 +79,8 @@ void create_map(Engine* engine)
 
         collider->shape.type = COLLISION_SHAPE_MESH;
 
+        //collider->restiution_coeff = 0.f;
+
         //PhysicsData* pd = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
         //physics_data_init(pd);
         //pd->mass = 0.f; // TODO: TEMP: Isn't moved by other things?
@@ -152,6 +154,9 @@ void engine_after_physics(Engine* engine, float physics_alpha)
 
 void engine_on_keyup(Engine* engine, WPARAM wParam)
 {
+    // TODO: rather than this maybe registering callbacks could be a good method.
+    //       can consider this down the line.
+
     switch (wParam)
     {
     case VK_F1:
@@ -327,7 +332,7 @@ void engine_on_lmbdown(Engine* engine)
         COMPONENT_MESH_INSTANCE);
     mesh_instance_init(mi, mb);
 
-
+    // TODO: helper for this.
     V3 colour =
     {
         random_float(),
@@ -342,10 +347,6 @@ void engine_on_lmbdown(Engine* engine)
     transform_init(transform);
     transform->position = v3_add_v3(engine->renderer.camera.position, v3_mul_f(engine->renderer.camera.direction, 3));
     transform->scale = v3_uniform(0.1f);
-
-
-    //transform->scale = v3_uniform(0.1);
-    //transform->scale = (V3){ 0.5f,2,1 };
 
     PhysicsData* physics_data = cecs_add_component(engine->ecs, cube_entity, COMPONENT_PHYSICS_DATA);
     physics_data_init(physics_data);


### PR DESCRIPTION
Closes #29 

Previously penetration depth was being directly used from ellipsoid space and being treated as world space. This is invalid for any case other than the ellipsoid being a unit sphere. Experimentation of a hack simply multiplying the depth by the radius of the ellipsoid would work if the ellipsoid was a uniformly scaled sphere. 

The collision normal was also incorrectly convert to world space, to preserve the normal, the inverse transpose of the transformation matrix should be used. In this case it is simply a diagonal scale, therefore, we can just divide by the scale.

Using our now correct world space normal, we can calculate the world space penetration depth by first calculating the penetration vector, i.e. the ellipsoid space vector to push the unit sphere out of the surface. Then we can convert this vector to world space simply multiplying by the ellipsoid scale, and projecting this penetration vector onto the world space collision normal as non-uniform scaling can change the vector direction.

Currently there are seemingly no issues with this solution, down the line this may change. This general fix of the collision packet data has solved the issue of the balls not resting on the floor which was caused by an invalid penetration depth.